### PR TITLE
Drag and drop elements within and between pages in edit mode

### DIFF
--- a/src/components/album.vue
+++ b/src/components/album.vue
@@ -1,7 +1,7 @@
 <template>
 	<div v-bind:class="['s-album', { 'editing': editMode }]" tabindex="0" v-on:keydown.prevent.left="showPrev" v-on:keydown.prevent.right="showNext"
     v-on:keydown.prevent.up="showPrev" v-on:keydown.prevent.down="showNext" v-on:keydown.prevent.space="diaporama(!diaporamaMode)"
-    v-on:keydown.e="onEditKey">
+    v-on:keydown.e="onEditKey" v-on:dragover="onAlbumDragOver">
 	    <i v-bind:class="isWinPortrait ? 'arrow-top': 'arrow-left'" v-on:click="showPrev"  v-if="!isTouchDevice"
             v-bind:style="{ visibility: aLeftVisible ? 'visible' : 'hidden', }"></i>
         <page v-for="(page, index) in pages" v-bind:s-num="index" v-bind:s-id="page.id" v-bind:displayed-page="displayedPage" v-bind:key="page.id"
@@ -11,7 +11,8 @@
             v-bind:is-last="index === pages.length - 1"
             v-on:remove-element="onRemoveElement" v-on:add-image="onAddImage"
             v-on:add-text="onAddText" v-on:cycle-layout="onCycleLayout"
-            v-on:add-page="onAddPage" v-on:move-page="onMovePage">
+            v-on:add-page="onAddPage" v-on:move-page="onMovePage"
+            v-on:element-drop="onElementDrop">
 	    </page>
 	    <i v-bind:class="isWinPortrait ? 'arrow-bottom': 'arrow-right'" v-on:click="showNext" v-if="!isTouchDevice"
             v-bind:style="{ visibility: aRightVisible ? 'visible' : 'hidden', }"></i>
@@ -77,7 +78,8 @@ import { NcLoadingIcon, NcActionInput, NcActionButton, NcActions, NcProgressBar,
 import Plus from 'vue-material-design-icons/Plus.vue'
 import JSZip from 'jszip'
 import { saveAs } from 'file-saver'
-import { setElementText, removeElement, buildImageElement, buildTextElement, buildPage, addElement } from '../utils/albumEdit.js'
+import { setElementText, removeElement, buildImageElement, buildTextElement, buildPage, addElement, swapElements } from '../utils/albumEdit.js'
+import { isElementDrag } from '../utils/elementDrag.js'
 import { cycleLayout } from '../utils/tilePageLayout.js'
 import { updatePage, searchAsset, cleanAssets, createPage, deletePage, movePage } from '../api/albumApi.js'
 import { getFilePickerBuilder, showError } from '@nextcloud/dialogs'
@@ -130,6 +132,9 @@ export default {
             "sAddPage": t("souvenirs","Add page"),
             "elementMargin": 1,
             "isTouchDevice": isTouchDevice(),
+            // Timestamp of the last page turn triggered by dragging an element
+            // near the album edge (throttles the edge navigation).
+            "dragNavLast": 0,
         }
     },
     created: function() {
@@ -453,6 +458,88 @@ export default {
                 that.$nextTick(() => { that.showN(index); });
                 showError(t("souvenirs","Could not move the page."));
             });
+        },
+        onElementDrop: function(srcPageId, srcElementId, destPageId, destElementId) {
+            if (srcPageId === destPageId) {
+                // Same page: swap the two elements' positions. Dropping on the
+                // page background or on itself is a no-op.
+                if (destElementId == null || destElementId === srcElementId) {
+                    return;
+                }
+                var index = this.pages.findIndex(p => p.id === destPageId);
+                if (index < 0) {
+                    return;
+                }
+                var updatedPage = swapElements(this.pages[index], srcElementId, destElementId);
+                this.pages.splice(index, 1, updatedPage);
+                updatePage(this.albumId, updatedPage).catch(error => {
+                    showError(t("souvenirs","Could not move the element."));
+                });
+                return;
+            }
+            // Other page: move the element there, with the same re-layout logic
+            // as adding a new element (issue #18).
+            var srcIndex = this.pages.findIndex(p => p.id === srcPageId);
+            var destIndex = this.pages.findIndex(p => p.id === destPageId);
+            if (srcIndex < 0 || destIndex < 0) {
+                return;
+            }
+            var element = (this.pages[srcIndex].elements || []).find(e => e.id === srcElementId);
+            if (element == null) {
+                return;
+            }
+            var that = this;
+            var updatedDest = addElement(this.pages[destIndex], element);
+            var updatedSrc = removeElement(this.pages[srcIndex], srcElementId);
+            this.pages.splice(destIndex, 1, updatedDest);
+            // Persist the destination first: if the source update then fails,
+            // the element at worst exists on both pages instead of being lost.
+            updatePage(this.albumId, updatedDest)
+                .then(() => {
+                    // Moving the last element away deletes the emptied page (same
+                    // rule as onRemoveElement), unless it is the only page left.
+                    if (updatedSrc.elements.length === 0 && that.pages.length > 1) {
+                        return deletePage(that.albumId, srcPageId).then(() => {
+                            var i = that.pages.findIndex(p => p.id === srcPageId);
+                            if (i >= 0) {
+                                that.pages.splice(i, 1);
+                            }
+                            if (that.displayedPage >= that.pages.length) {
+                                that.displayedPage = that.pages.length - 1;
+                            }
+                        });
+                    }
+                    var i = that.pages.findIndex(p => p.id === srcPageId);
+                    if (i >= 0) {
+                        that.pages.splice(i, 1, updatedSrc);
+                    }
+                    return updatePage(that.albumId, updatedSrc);
+                })
+                .catch(error => {
+                    showError(t("souvenirs","Could not move the element."));
+                });
+        },
+        onAlbumDragOver: function(event) {
+            // Dragging an element near the album edge turns the page, so the
+            // element can be dropped on a page that is not currently visible.
+            if (!this.editMode || !isElementDrag(event)) {
+                return;
+            }
+            var now = Date.now();
+            if (now - this.dragNavLast < 800) {
+                return;
+            }
+            var rect = document.querySelector(".s-album").getBoundingClientRect();
+            var zone = 80;
+            var toStart = this.isWinPortrait ? (event.clientY - rect.top) : (event.clientX - rect.left);
+            var toEnd = this.isWinPortrait ? (rect.bottom - event.clientY) : (rect.right - event.clientX);
+            if (toStart < zone) {
+                this.dragNavLast = now;
+                this.showPrev();
+            } else if (toEnd < zone) {
+                this.dragNavLast = now;
+                this.showNext();
+            }
         },
         onAddFirstPage: function() {
             // Bootstrap an empty album: enter edit mode and create the first page.

--- a/src/components/album.vue
+++ b/src/components/album.vue
@@ -2,26 +2,6 @@
 	<div v-bind:class="['s-album', { 'editing': editMode }]" tabindex="0" v-on:keydown.prevent.left="showPrev" v-on:keydown.prevent.right="showNext"
     v-on:keydown.prevent.up="showPrev" v-on:keydown.prevent.down="showNext" v-on:keydown.prevent.space="diaporama(!diaporamaMode)"
     v-on:keydown.e="onEditKey" v-on:dragover="onAlbumDragOver">
-	    <i v-bind:class="isWinPortrait ? 'arrow-top': 'arrow-left'" v-on:click="showPrev"  v-if="!isTouchDevice"
-            v-bind:style="{ visibility: aLeftVisible ? 'visible' : 'hidden', }"></i>
-        <page v-for="(page, index) in pages" v-bind:s-num="index" v-bind:s-id="page.id" v-bind:displayed-page="displayedPage" v-bind:key="page.id"
-            v-bind:elements="page.elements" v-bind:album-path="path" v-bind:is-win-portrait="isWinPortrait"
-            v-bind:token="token" v-on:imagefull="openImgFull" v-on:videofull="openVideoFull" v-bind:element-margin="elementMargin"
-            v-bind:edit-mode="editMode" v-on:edit-text="onEditText"
-            v-bind:is-last="index === pages.length - 1"
-            v-on:remove-element="onRemoveElement" v-on:add-image="onAddImage"
-            v-on:add-text="onAddText" v-on:cycle-layout="onCycleLayout"
-            v-on:add-page="onAddPage" v-on:move-page="onMovePage"
-            v-on:element-drop="onElementDrop">
-	    </page>
-	    <i v-bind:class="isWinPortrait ? 'arrow-bottom': 'arrow-right'" v-on:click="showNext" v-if="!isTouchDevice"
-            v-bind:style="{ visibility: aRightVisible ? 'visible' : 'hidden', }"></i>
-        <div v-bind:class="isWinPortrait ? 'progress-portrait': 'progress'" v-if="!isTouchDevice">
-            <div v-bind:class=" [ isWinPortrait ? 'progress-item-portrait': 'progress-item', index == displayedPage ? 'progress-item-full' : 'progress-item-empty']" v-for="(page, index) in pages" v-bind:key="index"
-            v-on:click="showN(index)">
-            </div>
-        </div>
-        <div v-if="editMode" class="edit-badge">{{ sEditing }}</div>
         <div class="top-right">
             <NcActions default-icon="icon-menu" :force-menu="true" :primary="true" v-if="!fullscreenMode">
                 <NcActionButton v-if="canEdit" @click="toggleEdit" :close-after-click="true">
@@ -40,6 +20,25 @@
                 <NcActionSeparator/>
                 <NcActionButton icon="icon-download" @click="openDownloadModal" :close-after-click="true">{{ sDownload }}</NcActionButton>
             </NcActions>
+        </div>
+	    <i v-bind:class="isWinPortrait ? 'arrow-top': 'arrow-left'" v-on:click="showPrev"  v-if="!isTouchDevice"
+            v-bind:style="{ visibility: aLeftVisible ? 'visible' : 'hidden', }"></i>
+        <page v-for="(page, index) in pages" v-bind:s-num="index" v-bind:s-id="page.id" v-bind:displayed-page="displayedPage" v-bind:key="page.id"
+            v-bind:elements="page.elements" v-bind:album-path="path" v-bind:is-win-portrait="isWinPortrait"
+            v-bind:token="token" v-on:imagefull="openImgFull" v-on:videofull="openVideoFull" v-bind:element-margin="elementMargin"
+            v-bind:edit-mode="editMode" v-on:edit-text="onEditText"
+            v-bind:is-last="index === pages.length - 1"
+            v-on:remove-element="onRemoveElement" v-on:add-image="onAddImage"
+            v-on:add-text="onAddText" v-on:cycle-layout="onCycleLayout"
+            v-on:add-page="onAddPage" v-on:move-page="onMovePage"
+            v-on:element-drop="onElementDrop">
+	    </page>
+	    <i v-bind:class="isWinPortrait ? 'arrow-bottom': 'arrow-right'" v-on:click="showNext" v-if="!isTouchDevice"
+            v-bind:style="{ visibility: aRightVisible ? 'visible' : 'hidden', }"></i>
+        <div v-bind:class="isWinPortrait ? 'progress-portrait': 'progress'" v-if="!isTouchDevice">
+            <div v-bind:class=" [ isWinPortrait ? 'progress-item-portrait': 'progress-item', index == displayedPage ? 'progress-item-full' : 'progress-item-empty']" v-for="(page, index) in pages" v-bind:key="index"
+            v-on:click="showN(index)">
+            </div>
         </div>
         <imagefull v-if="imageFullOn" v-bind:imageUrl="imageFullUrl" v-bind:isPhotosphere="imageFullIsPhotosphere"
             v-on:closeimagefull="closeImgFull">
@@ -128,7 +127,6 @@ export default {
             "sDownloadZip": t("souvenirs","Click to download album in a zip file."),
             "sEdit": t("souvenirs","Edit"),
             "sFinishEdit": t("souvenirs","Finish editing"),
-            "sEditing": t("souvenirs","Editing"),
             "sAddPage": t("souvenirs","Add page"),
             "elementMargin": 1,
             "isTouchDevice": isTouchDevice(),
@@ -875,27 +873,15 @@ function updateScrollWithPageDisplayed(el, dPage, isPortrait) {
 	position: absolute;
     right: 5px;
     top: 5px;
-    z-index: 6;
+    /* Above every in-page control (element delete/drag handles are 8, page
+       insert/move and progress are 9), so the menu stays reachable in edit mode. */
+    z-index: 10;
 }
 
 .s-album.editing {
     /* Make it unmistakable that the album is in edit mode. */
     outline: 4px solid var(--color-primary-element, #0082c9);
     outline-offset: -4px;
-}
-
-.edit-badge {
-    position: absolute;
-    left: 5px;
-    top: 5px;
-    z-index: 7;
-    padding: 4px 10px;
-    border-radius: var(--border-radius-pill, 14px);
-    background-color: var(--color-primary-element, #0082c9);
-    color: var(--color-primary-element-text, #ffffff);
-    font-weight: bold;
-    font-size: 13px;
-    pointer-events: none;
 }
  
 .top-left {

--- a/src/components/page.vue
+++ b/src/components/page.vue
@@ -1,5 +1,6 @@
 <template>
-    <div v-bind:class="(isWinPortrait ? 's-page-vert' : 's-page-hori')" v-bind:id="sId">
+    <div v-bind:class="(isWinPortrait ? 's-page-vert' : 's-page-hori')" v-bind:id="sId"
+        v-on:dragover="onPageDragOver" v-on:drop="onPageDrop">
 	<selement v-for="element in elements" v-bind:s-id="element.id" v-bind:s-top="element.top"
 				v-bind:s-bottom="element.bottom" v-bind:s-left="element.left"
 				v-bind:s-right="element.right" v-bind:s-text="element.text"
@@ -14,6 +15,7 @@
                 v-on:imagefull="openImgFull" v-on:videofull="openVideoFull"
                 v-bind:edit-mode="editMode" v-on:edit-text="onEditText"
                 v-on:remove-element="onRemoveElement"
+                v-bind:s-page-id="sId" v-on:element-drop="onElementDrop"
                 v-bind:element-margin="elementMargin">
 	</selement>
         <div v-if="editMode" class="page-insert page-insert--before" v-on:click="onAddPageBefore" :title="sAddPage">
@@ -71,6 +73,7 @@ import ViewDashboardVariantOutline from 'vue-material-design-icons/ViewDashboard
 import ChevronLeft from 'vue-material-design-icons/ChevronLeft.vue'
 import ChevronRight from 'vue-material-design-icons/ChevronRight.vue'
 import { canCycleLayout } from '../utils/tilePageLayout.js'
+import { isElementDrag, getElementDragData } from '../utils/elementDrag.js'
 
 export default {
     props: {
@@ -146,6 +149,31 @@ export default {
       onRemoveElement: function(elementId) {
         // Re-emit with this page's id (sId) so the album can locate the element.
         this.$emit("remove-element", this.sId, elementId);
+      },
+      onElementDrop: function(srcPageId, srcElementId, destElementId) {
+        // Drop landed on one of this page's elements: re-emit with this page as
+        // the destination so the album can swap (same page) or move (other page).
+        this.$emit("element-drop", srcPageId, srcElementId, this.sId, destElementId);
+      },
+      onPageDragOver: function(event) {
+        // preventDefault marks the page background as a valid drop target.
+        if (this.editMode && isElementDrag(event)) {
+          event.preventDefault();
+          event.dataTransfer.dropEffect = "move";
+        }
+      },
+      onPageDrop: function(event) {
+        // Drop on the page background (not on an element — those stop
+        // propagation): move the element onto this page.
+        if (!this.editMode || !isElementDrag(event)) {
+          return;
+        }
+        event.preventDefault();
+        var data = getElementDragData(event);
+        if (data == null) {
+          return;
+        }
+        this.$emit("element-drop", data.pageId, data.elementId, this.sId, null);
       },
       onAddImage: function() {
         // Ask the album to run the file picker and add an image to this page.

--- a/src/components/selement.vue
+++ b/src/components/selement.vue
@@ -2,13 +2,17 @@
     <div ref="eldiv" v-bind:class="['s-element', ((sClass.endsWith('ImageElement') || sClass.endsWith('VideoElement')) && sZoom < 100) ? 'blur-back' : '',
     { 's-element--draggable': isDraggable, 's-element--dragging': isDragging, 's-element--dragover': isDragOver }]"
     v-bind:id="sId"
-    v-bind:draggable="isDraggable"
+    v-bind:draggable="isDraggable && !dragSuppressed"
+    v-on:mousedown="onRootMouseDown"
     v-on:dragstart="onDragStart" v-on:dragend="onDragEnd"
     v-on:dragenter="onDragEnter" v-on:dragleave="onDragLeave"
     v-on:dragover="onDragOver" v-on:drop="onDrop"
     v-bind:style="'top:'+(sTop+elementMargin).toString()+'%;left:'+(sLeft+elementMargin).toString()+'%;width:'+(sRight-sLeft-2*elementMargin).toString()+'%;height:'+(sBottom-sTop-2*elementMargin).toString()+'%;--image-src-url:url(\''+ sImageSrc +'\')'">
 		<button v-if="editMode && isRemovable" class="s-element-delete" :title="removeTitle" v-on:click.stop="onRemove">
 			<Delete :size="20" />
+		</button>
+		<button v-if="isDraggable" class="s-element-drag-handle" :title="sDragToMove">
+			<CursorMove :size="20" />
 		</button>
 		<EditableText v-if="sText || editMode" class="s-element-text resize"
 			:value="sText" :editable="editMode" :auto-fit="true"
@@ -53,6 +57,7 @@ import { NcLoadingIcon } from '@nextcloud/vue'
 import { imagePath } from '@nextcloud/router'
 import EditableText from './EditableText.vue'
 import Delete from 'vue-material-design-icons/Delete.vue'
+import CursorMove from 'vue-material-design-icons/CursorMove.vue'
 import { setElementDragData, isElementDrag, getElementDragData } from '../utils/elementDrag.js'
 
 export default {
@@ -89,6 +94,11 @@ export default {
             "isVideoLoading": false,
             "isDragging": false,
             "isDragOver": false,
+            // True while the current press started inside the caption editor:
+            // the tile must not be draggable then, otherwise the browser
+            // suppresses caret placement / text selection in the contenteditable.
+            "dragSuppressed": false,
+            "sDragToMove": t("souvenirs","Drag to move"),
             // dragenter/dragleave also fire when moving over children, so the
             // drag-over highlight is tracked with an enter/leave counter.
             "dragOverCount": 0,
@@ -98,6 +108,7 @@ export default {
         NcLoadingIcon,
         EditableText,
         Delete,
+        CursorMove,
     },
     watch: {
         "geometryKey": function() {
@@ -260,8 +271,19 @@ export default {
             // Bubble the removal up with this element's id (sId).
             this.$emit("remove-element", this.sId);
         },
+        onRootMouseDown: function(event) {
+            // Decide per-press whether the tile is draggable: a press inside the
+            // caption editor must edit text, not start a drag. The browser makes
+            // the selection-vs-drag call during this very mousedown's default
+            // action, before Vue's async attribute patch would land, so the
+            // attribute is also updated synchronously here.
+            this.dragSuppressed = !!(event.target && event.target.isContentEditable);
+            if (this.$refs.eldiv) {
+                this.$refs.eldiv.setAttribute("draggable", String(this.isDraggable && !this.dragSuppressed));
+            }
+        },
         onDragStart: function(event) {
-            if (!this.isDraggable) {
+            if (!this.isDraggable || this.dragSuppressed) {
                 event.preventDefault();
                 return;
             }
@@ -380,6 +402,34 @@ function basename(path) {
 /* The tile being dragged: ghost it so the user sees it is in flight. */
 .s-element--dragging {
 	opacity: 0.4;
+}
+
+/* Grab handle, mirroring the delete button in the opposite corner. It floats
+   above the caption editor (which fills the whole cell on text tiles), so text
+   elements stay draggable even though a press inside the editor never drags. */
+.s-element-drag-handle {
+	position: absolute;
+	top: 6px;
+	left: 6px;
+	z-index: 8;
+	pointer-events: all;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 36px;
+	height: 36px;
+	padding: 0;
+	border: none;
+	border-radius: 50%;
+	cursor: grab;
+	color: var(--color-primary-element-text, #ffffff);
+	background-color: var(--color-primary-element, #0082c9);
+	box-shadow: 0 1px 4px rgba(0, 0, 0, 0.4);
+	opacity: 0.8;
+}
+
+.s-element-drag-handle:hover {
+	opacity: 1;
 }
 
 /* Valid drop target under the dragged tile. Inset dashed frame (the tile clips

--- a/src/components/selement.vue
+++ b/src/components/selement.vue
@@ -33,7 +33,10 @@
         <img v-bind:class="['paint-element', isImgCenterCrop ? 'centercrop' : '', isImgFill ? 'fill' : '' ]" v-if="sImage != '' && sClass.endsWith('PaintElement')" v-bind:src="sImageSrc" v-bind:draggable="!editMode"/>
         <div v-if="sMime == 'application/vnd.google.panorama360+jpg'" class="image-element-pano-icon"/>
         <div v-if="sVideo != null" class="image-element-video-icon"/>
-        <div v-bind:id="'pano-'+sId" style="position:absolute;top:0;left:0;width: 100%;height: 100%;"/>
+        <!-- In edit mode the tile takes pointer-events:all (drag and drop), which
+             would make this whole-tile overlay swallow clicks meant for the
+             caption editor below it: keep it click-through while editing. -->
+        <div v-bind:id="'pano-'+sId" v-bind:style="'position:absolute;top:0;left:0;width: 100%;height: 100%;' + (editMode ? 'pointer-events:none;' : '')"/>
         <div v-if="isVideoLoading" class="center">
             <NcLoadingIcon :size="64">
             </NcLoadingIcon>
@@ -422,14 +425,15 @@ function basename(path) {
 	border: none;
 	border-radius: 50%;
 	cursor: grab;
+	/* Same face as the primary NcButtons (e.g. "Add image"): full-strength
+	   primary color, no translucency. */
 	color: var(--color-primary-element-text, #ffffff);
 	background-color: var(--color-primary-element, #0082c9);
 	box-shadow: 0 1px 4px rgba(0, 0, 0, 0.4);
-	opacity: 0.8;
 }
 
 .s-element-drag-handle:hover {
-	opacity: 1;
+	background-color: var(--color-primary-element-hover, #198bce);
 }
 
 /* Valid drop target under the dragged tile. Inset dashed frame (the tile clips

--- a/src/components/selement.vue
+++ b/src/components/selement.vue
@@ -1,6 +1,11 @@
 <template>
-    <div ref="eldiv" v-bind:class="['s-element', ((sClass.endsWith('ImageElement') || sClass.endsWith('VideoElement')) && sZoom < 100) ? 'blur-back' : '']" 
+    <div ref="eldiv" v-bind:class="['s-element', ((sClass.endsWith('ImageElement') || sClass.endsWith('VideoElement')) && sZoom < 100) ? 'blur-back' : '',
+    { 's-element--draggable': isDraggable, 's-element--dragging': isDragging, 's-element--dragover': isDragOver }]"
     v-bind:id="sId"
+    v-bind:draggable="isDraggable"
+    v-on:dragstart="onDragStart" v-on:dragend="onDragEnd"
+    v-on:dragenter="onDragEnter" v-on:dragleave="onDragLeave"
+    v-on:dragover="onDragOver" v-on:drop="onDrop"
     v-bind:style="'top:'+(sTop+elementMargin).toString()+'%;left:'+(sLeft+elementMargin).toString()+'%;width:'+(sRight-sLeft-2*elementMargin).toString()+'%;height:'+(sBottom-sTop-2*elementMargin).toString()+'%;--image-src-url:url(\''+ sImageSrc +'\')'">
 		<button v-if="editMode && isRemovable" class="s-element-delete" :title="removeTitle" v-on:click.stop="onRemove">
 			<Delete :size="20" />
@@ -19,9 +24,9 @@
         </div>
         
 		<img id="image_element" v-bind:style="imageStyle" v-bind:class="['image-element', isImgCenterCrop ? 'centercrop' : '', isImgFill ? 'fill' : '' ]"
-        v-if="sImage != '' && (sClass.endsWith('ImageElement') || sClass.endsWith('VideoElement'))" 
-        v-bind:src="sImageSrc" v-on:click="openImgFull" />
-        <img v-bind:class="['paint-element', isImgCenterCrop ? 'centercrop' : '', isImgFill ? 'fill' : '' ]" v-if="sImage != '' && sClass.endsWith('PaintElement')" v-bind:src="sImageSrc"/>
+        v-if="sImage != '' && (sClass.endsWith('ImageElement') || sClass.endsWith('VideoElement'))"
+        v-bind:src="sImageSrc" v-on:click="openImgFull" v-bind:draggable="!editMode" />
+        <img v-bind:class="['paint-element', isImgCenterCrop ? 'centercrop' : '', isImgFill ? 'fill' : '' ]" v-if="sImage != '' && sClass.endsWith('PaintElement')" v-bind:src="sImageSrc" v-bind:draggable="!editMode"/>
         <div v-if="sMime == 'application/vnd.google.panorama360+jpg'" class="image-element-pano-icon"/>
         <div v-if="sVideo != null" class="image-element-video-icon"/>
         <div v-bind:id="'pano-'+sId" style="position:absolute;top:0;left:0;width: 100%;height: 100%;"/>
@@ -48,10 +53,13 @@ import { NcLoadingIcon } from '@nextcloud/vue'
 import { imagePath } from '@nextcloud/router'
 import EditableText from './EditableText.vue'
 import Delete from 'vue-material-design-icons/Delete.vue'
+import { setElementDragData, isElementDrag, getElementDragData } from '../utils/elementDrag.js'
 
 export default {
     props: {
       "sId": String,
+      // Id of the page hosting this element, needed as the drag payload source.
+      "sPageId": String,
       "editMode": Boolean,
       "sTop": Number,
       "sBottom": Number,
@@ -79,6 +87,11 @@ export default {
             "loadingImage": null,
             "imageStyle": {},
             "isVideoLoading": false,
+            "isDragging": false,
+            "isDragOver": false,
+            // dragenter/dragleave also fire when moving over children, so the
+            // drag-over highlight is tracked with an enter/leave counter.
+            "dragOverCount": 0,
         }
     },
     components: {
@@ -163,6 +176,11 @@ export default {
                 || this.sClass.endsWith('PaintElement')
                 || this.sClass.endsWith('TextElement'));
         },
+        'isDraggable': function() {
+            // The same visible tiles that can be removed can be dragged (Audio
+            // and unknown elements have no visual box to grab).
+            return this.editMode && this.isRemovable;
+        },
         'removeTitle': function() {
             return (this.sClass != null && this.sClass.endsWith('TextElement'))
                 ? t("souvenirs","Remove text")
@@ -242,6 +260,63 @@ export default {
             // Bubble the removal up with this element's id (sId).
             this.$emit("remove-element", this.sId);
         },
+        onDragStart: function(event) {
+            if (!this.isDraggable) {
+                event.preventDefault();
+                return;
+            }
+            // A drag starting inside the caption editor is the browser dragging
+            // selected text: leave it to the native behavior (our drop targets
+            // ignore it, as it does not carry the element payload).
+            if (event.target && event.target.isContentEditable) {
+                return;
+            }
+            setElementDragData(event, this.sPageId, this.sId);
+            this.isDragging = true;
+        },
+        onDragEnd: function() {
+            this.isDragging = false;
+        },
+        onDragEnter: function(event) {
+            if (!this.editMode || !isElementDrag(event)) {
+                return;
+            }
+            this.dragOverCount += 1;
+            this.isDragOver = !this.isDragging;
+        },
+        onDragLeave: function(event) {
+            if (!this.editMode || !isElementDrag(event)) {
+                return;
+            }
+            this.dragOverCount -= 1;
+            if (this.dragOverCount <= 0) {
+                this.dragOverCount = 0;
+                this.isDragOver = false;
+            }
+        },
+        onDragOver: function(event) {
+            // preventDefault marks this element as a valid drop target.
+            if (this.editMode && isElementDrag(event)) {
+                event.preventDefault();
+                event.dataTransfer.dropEffect = "move";
+            }
+        },
+        onDrop: function(event) {
+            this.dragOverCount = 0;
+            this.isDragOver = false;
+            if (!this.editMode || !isElementDrag(event)) {
+                return;
+            }
+            event.preventDefault();
+            // Do not let the page treat this as a drop on its background.
+            event.stopPropagation();
+            var data = getElementDragData(event);
+            if (data == null) {
+                return;
+            }
+            // Bubble up: source (page, element) + this element as drop target.
+            this.$emit("element-drop", data.pageId, data.elementId, this.sId);
+        },
         waitingVideo: function() {
             this.isVideoLoading = true;
         },
@@ -293,6 +368,25 @@ function basename(path) {
 	justify-content: center;
     pointer-events: none;
     overflow: hidden;
+}
+
+/* Draggable tiles (edit mode) must receive pointer/drag events; the base
+   .s-element disables them (children normally opt back in). */
+.s-element--draggable {
+	pointer-events: all;
+	cursor: grab;
+}
+
+/* The tile being dragged: ghost it so the user sees it is in flight. */
+.s-element--dragging {
+	opacity: 0.4;
+}
+
+/* Valid drop target under the dragged tile. Inset dashed frame (the tile clips
+   its overflow, so an offset outline would be cut on the page edges). */
+.s-element--dragover {
+	outline: 3px dashed var(--color-primary-element, #0082c9);
+	outline-offset: -3px;
 }
 
 .s-element-delete {

--- a/src/components/selement.vue
+++ b/src/components/selement.vue
@@ -11,9 +11,12 @@
 		<button v-if="editMode && isRemovable" class="s-element-delete" :title="removeTitle" v-on:click.stop="onRemove">
 			<Delete :size="20" />
 		</button>
-		<button v-if="isDraggable" class="s-element-drag-handle" :title="sDragToMove">
-			<CursorMove :size="20" />
-		</button>
+		<NcButton v-if="isDraggable" class="s-element-drag-handle" type="primary"
+			:aria-label="sDragToMove" :title="sDragToMove">
+			<template #icon>
+				<CursorMove :size="20" />
+			</template>
+		</NcButton>
 		<EditableText v-if="sText || editMode" class="s-element-text resize"
 			:value="sText" :editable="editMode" :auto-fit="true"
 			@save="onTextSave" />
@@ -56,7 +59,7 @@ import { Viewer } from '@photo-sphere-viewer/core';
 import '@photo-sphere-viewer/core/index.css';
 import { AutorotatePlugin } from '@photo-sphere-viewer/autorotate-plugin';
 import { VisibleRangePlugin } from '@photo-sphere-viewer/visible-range-plugin';
-import { NcLoadingIcon } from '@nextcloud/vue'
+import { NcLoadingIcon, NcButton } from '@nextcloud/vue'
 import { imagePath } from '@nextcloud/router'
 import EditableText from './EditableText.vue'
 import Delete from 'vue-material-design-icons/Delete.vue'
@@ -109,6 +112,7 @@ export default {
     },
     components: {
         NcLoadingIcon,
+        NcButton,
         EditableText,
         Delete,
         CursorMove,
@@ -409,31 +413,20 @@ function basename(path) {
 
 /* Grab handle, mirroring the delete button in the opposite corner. It floats
    above the caption editor (which fills the whole cell on text tiles), so text
-   elements stay draggable even though a press inside the editor never drags. */
+   elements stay draggable even though a press inside the editor never drags.
+   It is a primary NcButton so its face (color, hover) is exactly the one of the
+   other edit buttons ("Add image", ...); only placement is set here. */
 .s-element-drag-handle {
 	position: absolute;
 	top: 6px;
 	left: 6px;
 	z-index: 8;
 	pointer-events: all;
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	width: 36px;
-	height: 36px;
-	padding: 0;
-	border: none;
-	border-radius: 50%;
-	cursor: grab;
-	/* Same face as the primary NcButtons (e.g. "Add image"): full-strength
-	   primary color, no translucency. */
-	color: var(--color-primary-element-text, #ffffff);
-	background-color: var(--color-primary-element, #0082c9);
-	box-shadow: 0 1px 4px rgba(0, 0, 0, 0.4);
 }
 
-.s-element-drag-handle:hover {
-	background-color: var(--color-primary-element-hover, #198bce);
+.s-element-drag-handle,
+.s-element-drag-handle :deep(*) {
+	cursor: grab;
 }
 
 /* Valid drop target under the dragged tile. Inset dashed frame (the tile clips

--- a/src/utils/__tests__/albumEdit.test.js
+++ b/src/utils/__tests__/albumEdit.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { setElementText, relayoutElements, removeElement, buildImageElement, buildTextElement, buildPage, addElement } from '../albumEdit.js'
+import { setElementText, relayoutElements, removeElement, buildImageElement, buildTextElement, buildPage, addElement, swapElements } from '../albumEdit.js'
 
 describe('setElementText', () => {
     const makePage = () => ({
@@ -237,6 +237,61 @@ describe('buildPage', () => {
 
     it('gives each call a distinct id', () => {
         expect(buildPage().id).not.toBe(buildPage().id)
+    })
+})
+
+describe('swapElements', () => {
+    const makePage = () => ({
+        id: 'page-1',
+        customPageField: 'keep-me',
+        elements: [
+            { id: 'el-1', class: 'ImageElement', image: 'data/a.jpg', zoom: 120, offsetX: 5, androidOnlyField: 42, top: 0, left: 0, right: 100, bottom: 50 },
+            { id: 'el-2', class: 'TextElement', text: 'hi', top: 50, left: 0, right: 100, bottom: 100 },
+            { id: 'el-3', class: 'AudioElement', audio: 'data/x.mp3' },
+        ],
+    })
+
+    it('exchanges the geometry of the two elements', () => {
+        const result = swapElements(makePage(), 'el-1', 'el-2')
+        const image = result.elements.find(e => e.id === 'el-1')
+        const text = result.elements.find(e => e.id === 'el-2')
+        expect(image).toMatchObject({ top: 50, left: 0, right: 100, bottom: 100 })
+        expect(text).toMatchObject({ top: 0, left: 0, right: 100, bottom: 50 })
+    })
+
+    it('exchanges the array slots too, so a later re-layout keeps the swap', () => {
+        const result = swapElements(makePage(), 'el-1', 'el-2')
+        expect(result.elements.map(e => e.id)).toEqual(['el-2', 'el-1', 'el-3'])
+    })
+
+    it('keeps the per-slot geometry sequence (layout detection still matches)', () => {
+        const result = swapElements(makePage(), 'el-1', 'el-2')
+        expect(result.elements[0]).toMatchObject({ top: 0, bottom: 50 })
+        expect(result.elements[1]).toMatchObject({ top: 50, bottom: 100 })
+    })
+
+    it('preserves all non-geometry fields, including unknown ones', () => {
+        const result = swapElements(makePage(), 'el-1', 'el-2')
+        const image = result.elements.find(e => e.id === 'el-1')
+        expect(image).toMatchObject({ image: 'data/a.jpg', zoom: 120, offsetX: 5, androidOnlyField: 42 })
+        expect(result.customPageField).toBe('keep-me')
+    })
+
+    it('is a no-op when either id is missing or both are the same', () => {
+        const before = makePage().elements
+        expect(swapElements(makePage(), 'el-1', 'missing').elements).toEqual(before)
+        expect(swapElements(makePage(), 'missing', 'el-2').elements).toEqual(before)
+        expect(swapElements(makePage(), 'el-1', 'el-1').elements).toEqual(before)
+    })
+
+    it('does not mutate the original page', () => {
+        const page = makePage()
+        swapElements(page, 'el-1', 'el-2')
+        expect(page.elements[0]).toMatchObject({ id: 'el-1', top: 0 })
+    })
+
+    it('tolerates a page without an elements array', () => {
+        expect(swapElements({ id: 'p' }, 'a', 'b').elements).toEqual([])
     })
 })
 

--- a/src/utils/__tests__/elementDrag.test.js
+++ b/src/utils/__tests__/elementDrag.test.js
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest'
+import { ELEMENT_DRAG_TYPE, setElementDragData, isElementDrag, getElementDragData } from '../elementDrag.js'
+
+// Minimal DataTransfer stand-in (jsdom does not implement DataTransfer).
+function makeEvent() {
+    const store = {}
+    return {
+        dataTransfer: {
+            effectAllowed: null,
+            get types() { return Object.keys(store) },
+            setData(type, value) { store[type] = value },
+            getData(type) { return store[type] ?? '' },
+        },
+    }
+}
+
+describe('element drag payload', () => {
+    it('round-trips the page and element ids through the DataTransfer', () => {
+        const event = makeEvent()
+        setElementDragData(event, 'page-1', 'el-1')
+        expect(isElementDrag(event)).toBe(true)
+        expect(getElementDragData(event)).toEqual({ pageId: 'page-1', elementId: 'el-1' })
+    })
+
+    it('requests a move effect', () => {
+        const event = makeEvent()
+        setElementDragData(event, 'page-1', 'el-1')
+        expect(event.dataTransfer.effectAllowed).toBe('move')
+    })
+
+    it('does not recognize foreign drags (files, text selections)', () => {
+        const event = makeEvent()
+        event.dataTransfer.setData('text/plain', 'hello')
+        expect(isElementDrag(event)).toBe(false)
+        expect(getElementDragData(event)).toBe(null)
+    })
+
+    it('returns null on a malformed payload instead of throwing', () => {
+        const event = makeEvent()
+        event.dataTransfer.setData(ELEMENT_DRAG_TYPE, 'not json')
+        expect(getElementDragData(event)).toBe(null)
+        event.dataTransfer.setData(ELEMENT_DRAG_TYPE, JSON.stringify({ pageId: 1 }))
+        expect(getElementDragData(event)).toBe(null)
+    })
+
+    it('tolerates events without a dataTransfer', () => {
+        expect(isElementDrag({ dataTransfer: null })).toBe(false)
+        expect(getElementDragData({ dataTransfer: null })).toBe(null)
+    })
+})

--- a/src/utils/albumEdit.js
+++ b/src/utils/albumEdit.js
@@ -122,6 +122,38 @@ export function addElement(page, element) {
 }
 
 /**
+ * Return a copy of `page` in which the elements identified by `elementIdA` and
+ * `elementIdB` have exchanged places: each takes the other's geometry
+ * (top/left/right/bottom) AND the other's slot in the elements array. Swapping
+ * the array slots too keeps the visual order and the persisted order in sync,
+ * so a later re-layout (e.g. adding an element) does not undo the swap.
+ * Everything else (zoom/offset, captions, unknown fields, ...) is preserved.
+ *
+ * If either id is missing, or both are the same element, the page is returned
+ * unchanged (as a copy).
+ *
+ * @param {object} page - a page object, expected to contain an `elements` array
+ * @param {string} elementIdA - the `id` of the first element
+ * @param {string} elementIdB - the `id` of the second element
+ * @returns {object} a new page object with the two elements swapped
+ */
+export function swapElements(page, elementIdA, elementIdB) {
+    const elements = Array.isArray(page.elements) ? page.elements : []
+    const swapped = elements.map(element => ({ ...element }))
+    const indexA = elements.findIndex(element => element.id === elementIdA)
+    const indexB = elements.findIndex(element => element.id === elementIdB)
+    if (indexA >= 0 && indexB >= 0 && indexA !== indexB) {
+        const geometry = ({ top, left, right, bottom }) => ({ top, left, right, bottom })
+        swapped[indexA] = { ...elements[indexB], ...geometry(elements[indexA]) }
+        swapped[indexB] = { ...elements[indexA], ...geometry(elements[indexB]) }
+    }
+    return {
+        ...page,
+        elements: swapped,
+    }
+}
+
+/**
  * Return a copy of `page` in which the element identified by `elementId` has its
  * `text` set to `newText`. All other fields of the page and of every element
  * (including ones this app does not know about) are preserved untouched.

--- a/src/utils/elementDrag.js
+++ b/src/utils/elementDrag.js
@@ -1,0 +1,56 @@
+/**
+ * Shared helpers for the HTML5 drag and drop of album elements.
+ *
+ * The drag payload (source page id + element id) travels through the native
+ * DataTransfer under a custom MIME type, so element drags are distinguishable
+ * from any other drag (files, text selections from the caption editor, ...).
+ * During dragover the payload itself is not readable (HTML5 restriction), so
+ * drop acceptance is checked from the type list alone.
+ */
+
+export const ELEMENT_DRAG_TYPE = 'application/x-souvenirs-element'
+
+/**
+ * Attach an element-drag payload to a dragstart event.
+ *
+ * @param {DragEvent} event - the dragstart event
+ * @param {string} pageId - id of the page the element is dragged from
+ * @param {string} elementId - id of the dragged element
+ */
+export function setElementDragData(event, pageId, elementId) {
+    event.dataTransfer.effectAllowed = 'move'
+    event.dataTransfer.setData(ELEMENT_DRAG_TYPE, JSON.stringify({ pageId: pageId, elementId: elementId }))
+}
+
+/**
+ * Whether the ongoing drag carries an element payload (usable during dragover,
+ * when the payload content is not yet readable).
+ *
+ * @param {DragEvent} event
+ * @returns {boolean}
+ */
+export function isElementDrag(event) {
+    return event.dataTransfer != null
+        && Array.prototype.includes.call(event.dataTransfer.types, ELEMENT_DRAG_TYPE)
+}
+
+/**
+ * Read the element-drag payload from a drop event.
+ *
+ * @param {DragEvent} event
+ * @returns {?{pageId: string, elementId: string}} the payload, or null if absent/malformed
+ */
+export function getElementDragData(event) {
+    if (event.dataTransfer == null) {
+        return null
+    }
+    try {
+        const data = JSON.parse(event.dataTransfer.getData(ELEMENT_DRAG_TYPE))
+        if (data != null && typeof data.pageId === 'string' && typeof data.elementId === 'string') {
+            return data
+        }
+    } catch (e) {
+        // Not our payload (or malformed): treat as no element drag.
+    }
+    return null
+}


### PR DESCRIPTION
In edit mode, elements can now be dragged: dropping on another element of the same page swaps their positions; dropping on another page moves the element there, re-laid-out like a newly added element. Dragging near the album edge turns the page.

Closes #18