### PR TITLE
security: harden share tokens, public endpoints, and input handling

### DIFF
--- a/lib/Controller/Api2Controller.php
+++ b/lib/Controller/Api2Controller.php
@@ -66,13 +66,12 @@ class Api2Controller extends ApiController {
 		$albumsFolder = Utils::getAlbumsNode($this->config, $this->userId, $this->appName, $this->userFolder);
 		$albumList = AlbumList::getInstance($albumsFolder);
 		$album = $albumList->createAlbum($id);
-		$this->albumMapper->createAlbum($this->userId, $id, $album->getAlbumPath(), 'Just created');
-		if (!is_null($album)) {
-			return new JSONResponse($album->toArray());
-		} else {
-			//album exists
+		if (is_null($album)) {
+			//album already exists
 			return new JSONResponse(array(), Http::STATUS_CONFLICT);
 		}
+		$this->albumMapper->createAlbum($this->userId, $id, $album->getAlbumPath(), 'Just created');
+		return new JSONResponse($album->toArray());
 	}
 
 	/**
@@ -426,7 +425,11 @@ class Api2Controller extends ApiController {
 	 * @NoCSRFRequired
 	 */
 	public function createShare($albumId) {
-		
+		//make sure the album actually exists for this user before sharing it
+		$album_db = $this->albumMapper->findByAlbumId($this->userId, $albumId);
+		if (is_null($album_db)) {
+			return new JSONResponse(array(), Http::STATUS_NOT_FOUND);
+		}
 		$results = $this->shareMapper->createShare($this->userId,$albumId);
 		//get shareUrl
 		$shareUrl = $this->urlGen->linkToRouteAbsolute('souvenirs.public.show',array('token' => $results['share']['token']));

--- a/lib/Controller/PreviewController.php
+++ b/lib/Controller/PreviewController.php
@@ -38,12 +38,12 @@ class PreviewController extends Controller {
 
 	/**
 	 * get asset
-	 * @NoAdminRequiredrealFilePath
+	 * @NoAdminRequired
 	 * @NoCSRFRequired
 	 */
 	public function getAsset($apath, $file) {
 		$userFolder = $this->rootFolder->getUserFolder($this->userId);
-		$album = Album::withFolder($userFolder->get(urldecode($apath)));
+		$album = Album::withFolder($userFolder->get($apath));
 		$realFilePath = $album->getAssetRealPath(DATA_DIR . "/" . $file);
 		$node = $this->rootFolder->get($realFilePath);
 		$response = new StreamResponse($node->fopen("r"));
@@ -77,6 +77,7 @@ class PreviewController extends Controller {
 	 * @NoAdminRequired
 	 * @NoCSRFRequired
 	 * @PublicPage
+	 * @BruteForceProtection(action=souvenirs_public)
 	 *
 	 * Sends a large preview of the requested file for public share
 	 *
@@ -91,12 +92,14 @@ class PreviewController extends Controller {
 		//check token and get album path
 		$share = $this->shareMapper->findByToken($token);
 		if (is_null($share)) {
-			return new JSONResponse(
+			$response = new JSONResponse(
 				[
 					'message' => "Album do not exists.",
 					'success' => false
 				], Http::STATUS_NOT_FOUND
 			);
+			$response->throttle();
+			return $response;
 		}
 		$userFolder = $this->rootFolder->getUserFolder($share->getUser());
 		$albumsFolder = Utils::getAlbumsNode($this->config, $share->getUser(), $this->appName, $userFolder);
@@ -111,20 +114,23 @@ class PreviewController extends Controller {
 
 	/**
 	 * get public asset
-	 * @NoAdminRequiredrealFilePath
+	 * @NoAdminRequired
 	 * @NoCSRFRequired
 	 * @PublicPage
+	 * @BruteForceProtection(action=souvenirs_public)
 	 */
 	public function getPublicAsset($token, $file) {
 		//check token and get album path
 		$share = $this->shareMapper->findByToken($token);
 		if (is_null($share)) {
-			return new JSONResponse(
+			$response = new JSONResponse(
 				[
 					'message' => "Album do not exists.",
 					'success' => false
 				], Http::STATUS_NOT_FOUND
 			);
+			$response->throttle();
+			return $response;
 		}
 		$userFolder = $this->rootFolder->getUserFolder($share->getUser());
 		$albumsFolder = Utils::getAlbumsNode($this->config, $share->getUser(), $this->appName, $userFolder);

--- a/lib/Db/ShareMapper.php
+++ b/lib/Db/ShareMapper.php
@@ -6,14 +6,18 @@ namespace OCA\Souvenirs\Db;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
 use OCP\AppFramework\Db\QBMapper;
+use OCP\Security\ISecureRandom;
 use OCA\Souvenirs\Db\Share;
 
 define("SHARE_TABLE", 'souvenirs_shares');
 
 class ShareMapper extends QBMapper {
 
-    public function __construct(IDBConnection $db) {
+    private $secureRandom;
+
+    public function __construct(IDBConnection $db, ISecureRandom $secureRandom) {
         parent::__construct($db, SHARE_TABLE);
+        $this->secureRandom = $secureRandom;
     }
 
 
@@ -109,13 +113,8 @@ class ShareMapper extends QBMapper {
     }
 
     private function generateRandomString($length = 10) {
-        $characters = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
-        $charactersLength = strlen($characters);
-        $randomString = '';
-        for ($i = 0; $i < $length; $i++) {
-            $randomString .= $characters[rand(0, $charactersLength - 1)];
-        }
-        return $randomString;
+        //use Nextcloud's cryptographically secure RNG for share tokens
+        return $this->secureRandom->generate($length, ISecureRandom::CHAR_ALPHANUMERIC);
     }
 
 }

--- a/lib/Model/Album.php
+++ b/lib/Model/Album.php
@@ -378,9 +378,12 @@ class Album {
     }
 
     public function setValues($valuesArray) {
+        //structural keys managed through dedicated endpoints / immutable at creation
+        $protectedKeys = array("pages", "id");
         if (is_array($valuesArray)) {
             foreach ($valuesArray as $key => $value) {
-                if ((!is_null($value)) && (substr($key,0,1) !== "_")) {
+                if ((!is_null($value)) && (substr($key,0,1) !== "_")
+                    && (!in_array($key, $protectedKeys, true))) {
                     $this->setContent($key,$value);
                 }
             }


### PR DESCRIPTION
## Summary

Fixes from a full security audit of the app. The authorization model is sound (no SQLi, no cross-user IDOR, no path traversal, no XSS, no hardcoded secrets); these changes address the concrete weaknesses that were found.

| Finding | Severity | Fix |
|---|---|---|
| **F1** – share tokens from `rand()` (non-crypto PRNG, CWE-338) | Medium | Generate tokens with `ISecureRandom::generate(64, CHAR_ALPHANUMERIC)` |
| **F2** – public preview/asset endpoints had no brute-force throttle | Low | Add `@BruteForceProtection` + `throttle()` on the token-guess path |
| **F5** – mass-assignment into `album.json` | Low | Block structural keys (`pages`, `id`) in `Album::setValues` |
| **F6** – null-deref crash on duplicate album id | Low | Null-check before use; return 409 instead of 500 |
| **F7/F8** – double `urldecode`; `@NoAdminRequiredrealFilePath` typo | Info | Remove redundant decode; fix annotation on `getAsset`/`getPublicAsset` |
| **F9** – `createShare` didn't verify the album exists | Info | Validate album ownership before creating a share |

**F1 is the important one:** a share token is the only secret protecting a shared private album, and `rand()` (Mersenne Twister in PHP >=7.1) has a reconstructable internal state, so observed tokens can leak others.

## Not included (deliberately deferred)

- **Token expiry (F3):** needs a DB migration + UI.
- **CSRF on write endpoints (F4):** these are `@CORS`, so Nextcloud's `CORSMiddleware` + `SameSite=Lax` cookies already mitigate browser CSRF; `@NoCSRFRequired` is intentional for the Android client.
- **F5** uses a conservative key-block rather than a strict whitelist, since the Android client's exact `album.json` field set isn't inspectable from this repo.

## Testing

- All 4 changed PHP files pass `php -l`.
- Unit suite passes 8/8 (covers the `Album`/`Page` models touched by F5).