### PR TITLE
Cleaner photosphere viewer in album view

### DIFF
--- a/src/components/page.vue
+++ b/src/components/page.vue
@@ -204,6 +204,10 @@ export default {
     },
     mounted: function() {
         fitText();
+        // The displayedPage watcher only fires on navigation, so without this
+        // the initially displayed page would stay unfocused until the user
+        // leaves it and comes back (no photosphere rotation / video autoplay).
+        this.isFocus = (this.displayedPage == this.sNum);
     }
 }
 

--- a/src/components/selement.vue
+++ b/src/components/selement.vue
@@ -141,6 +141,13 @@ export default {
             }
         },
         "isFocus": function(newFocus,oldFocus) {
+            if (this.autorotate != null && this.panoReady) {
+                if (newFocus) {
+                    this.autorotate.start();
+                } else {
+                    this.autorotate.stop();
+                }
+            }
             if (this.sClass == 'VideoElement') {
                 if (newFocus != oldFocus) {
                     let video = document.getElementById(this.sId+"video");
@@ -159,6 +166,10 @@ export default {
         }
     },
     created: function() {
+            // Plain properties, not data(): wrapping the Photo Sphere Viewer
+            // plugin in a reactive proxy is useless and fragile.
+            this.autorotate = null;
+            this.panoReady = false;
             if (this.preload) {
                 this.loadImage();
             }
@@ -235,14 +246,27 @@ export default {
                     panorama: this.imageUrl(true),
                     container: "pano-"+this.sId,
                     loadingImg: imagePath('souvenirs','loading.gif'),
-                    navbar: [],
-                    plugins: [ 
-                        AutorotatePlugin.withConfig(),
+                    // false, not []: an empty list still renders the translucent bar.
+                    navbar: false,
+                    plugins: [
+                        AutorotatePlugin.withConfig({
+                            // Rotation is driven by page focus (see the isFocus
+                            // watcher), not by the plugin's own autostart/idle timers.
+                            autostartDelay: null,
+                            autostartOnIdle: false,
+                        }),
                         VisibleRangePlugin.withConfig({
                             usePanoData: true,
                         }),
                      ],
                 });
+                this.autorotate = pano.getPlugin(AutorotatePlugin);
+                pano.addEventListener('ready', () => {
+                    this.panoReady = true;
+                    if (this.isFocus) {
+                        this.autorotate.start();
+                    }
+                }, { once: true });
             }
         },
         imageUrl: function(full = false) {


### PR DESCRIPTION
Closes #21

- **Remove the bottom bar in album view**: the tile viewer was created with `navbar: []`, which still renders the empty grey translucent bar; it now uses `navbar: false`. The full-screen view keeps its navbar (zoom/move/close).
- **Stop rotating when not in focus**: the autorotate plugin no longer self-starts (`autostartDelay: null`, `autostartOnIdle: false`); rotation is started/stopped from the existing `isFocus` watcher, the same signal that already pauses videos. A photosphere rotates only while its page is the displayed one.
- **First-page focus fix**: `isFocus` was only set by the `displayedPage` watcher, which never fires for the initially displayed page, so a photosphere there never rotated. `mounted` now initializes it. Side effect: a video on the initially displayed page now autoplays on album open, consistent with every other page.

Note: since idle-restart is disabled, manually dragging a photosphere in album view stops its rotation until the page regains focus.
