### PR TITLE
Resize elements with corner drag handles in edit mode

### DIFF
--- a/src/components/__tests__/selement.resize.test.js
+++ b/src/components/__tests__/selement.resize.test.js
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import Selement from '../selement.vue'
+
+// Mount an element tile inside a fake 1000x1000px page, so pointer deltas in px
+// map 1:1 to page percentages / 10.
+function mountTile(props = {}) {
+    const wrapper = mount(Selement, {
+        attachTo: document.body,
+        props: {
+            sId: 'el-1',
+            sPageId: 'page-1',
+            editMode: true,
+            sClass: 'ImageElement',
+            sImage: '',
+            sText: '',
+            sTop: 0,
+            sBottom: 50,
+            sLeft: 0,
+            sRight: 50,
+            sZoom: 100,
+            sOffsetX: 0,
+            sOffsetY: 0,
+            sTransformType: 1,
+            albumPath: 'Souvenirs/test',
+            token: '',
+            preload: false,
+            isFocus: false,
+            elementMargin: 1,
+            ...props,
+        },
+    })
+    // The component converts pointer deltas against its positioned parent (the
+    // page); happy-dom has no layout, so give the parent a concrete box.
+    wrapper.element.parentElement.getBoundingClientRect = () => ({
+        width: 1000, height: 1000, top: 0, left: 0, right: 1000, bottom: 1000, x: 0, y: 0,
+    })
+    return wrapper
+}
+
+async function dragHandle(wrapper, corner, from, to) {
+    const handle = wrapper.find('.s-element-resize-handle--' + corner)
+    await handle.trigger('pointerdown', { pointerId: 1, clientX: from.x, clientY: from.y })
+    await handle.trigger('pointermove', { pointerId: 1, clientX: to.x, clientY: to.y })
+    await handle.trigger('pointerup', { pointerId: 1, clientX: to.x, clientY: to.y })
+}
+
+describe('selement corner resize', () => {
+    it('shows the four corner handles in edit mode only', () => {
+        expect(mountTile().findAll('.s-element-resize-handle')).toHaveLength(4)
+        expect(mountTile({ editMode: false }).findAll('.s-element-resize-handle')).toHaveLength(0)
+    })
+
+    it('does not show handles on non-resizable elements (audio)', () => {
+        expect(mountTile({ sClass: 'AudioElement' }).findAll('.s-element-resize-handle')).toHaveLength(0)
+    })
+
+    it('emits resize-element with the new geometry after dragging the SE corner', async () => {
+        const wrapper = mountTile()
+        await dragHandle(wrapper, 'se', { x: 500, y: 500 }, { x: 700, y: 600 })
+        const emitted = wrapper.emitted('resize-element')
+        expect(emitted).toBeTruthy()
+        expect(emitted[0]).toEqual(['el-1', { top: 0, left: 0, right: 70, bottom: 60 }])
+    })
+
+    it('moves only the grabbed corner edges (NW drag keeps right/bottom)', async () => {
+        const wrapper = mountTile({ sTop: 20, sLeft: 20, sRight: 80, sBottom: 80 })
+        await dragHandle(wrapper, 'nw', { x: 200, y: 200 }, { x: 100, y: 300 })
+        expect(wrapper.emitted('resize-element')[0][1]).toEqual({ top: 30, left: 10, right: 80, bottom: 80 })
+    })
+
+    it('clamps to the page bounds and to the minimum size', async () => {
+        const wrapper = mountTile()
+        // Way beyond the page on both axes: right/bottom stop at 100.
+        await dragHandle(wrapper, 'se', { x: 500, y: 500 }, { x: 5000, y: 5000 })
+        expect(wrapper.emitted('resize-element')[0][1]).toEqual({ top: 0, left: 0, right: 100, bottom: 100 })
+        // Collapse toward the opposite corner: 5% minimum is kept.
+        const wrapper2 = mountTile()
+        await dragHandle(wrapper2, 'se', { x: 500, y: 500 }, { x: -5000, y: -5000 })
+        expect(wrapper2.emitted('resize-element')[0][1]).toEqual({ top: 0, left: 0, right: 5, bottom: 5 })
+    })
+
+    it('previews the geometry live while dragging', async () => {
+        const wrapper = mountTile()
+        const handle = wrapper.find('.s-element-resize-handle--se')
+        await handle.trigger('pointerdown', { pointerId: 1, clientX: 500, clientY: 500 })
+        await handle.trigger('pointermove', { pointerId: 1, clientX: 700, clientY: 600 })
+        // elementMargin is 1: rendered box = logical box inset by 1%.
+        expect(wrapper.element.style.width).toBe('68%')
+        expect(wrapper.element.style.height).toBe('58%')
+        // Nothing is committed before the pointer is released.
+        expect(wrapper.emitted('resize-element')).toBeFalsy()
+        await handle.trigger('pointercancel', { pointerId: 1 })
+        // A cancelled gesture snaps back to the committed geometry.
+        expect(wrapper.element.style.width).toBe('48%')
+        expect(wrapper.emitted('resize-element')).toBeFalsy()
+    })
+
+    it('does not emit when the geometry did not change', async () => {
+        const wrapper = mountTile()
+        await dragHandle(wrapper, 'se', { x: 500, y: 500 }, { x: 500, y: 500 })
+        expect(wrapper.emitted('resize-element')).toBeFalsy()
+    })
+})

--- a/src/components/__tests__/selement.resize.test.js
+++ b/src/components/__tests__/selement.resize.test.js
@@ -55,6 +55,15 @@ describe('selement corner resize', () => {
         expect(mountTile({ sClass: 'AudioElement' }).findAll('.s-element-resize-handle')).toHaveLength(0)
     })
 
+    it('keeps paint elements static: no resize handles, no drag handle, not draggable', () => {
+        const wrapper = mountTile({ sClass: 'PaintElement' })
+        expect(wrapper.findAll('.s-element-resize-handle')).toHaveLength(0)
+        expect(wrapper.find('.s-element-drag-handle').exists()).toBe(false)
+        expect(wrapper.attributes('draggable')).toBe('false')
+        // Still removable: the delete button stays.
+        expect(wrapper.find('.s-element-delete').exists()).toBe(true)
+    })
+
     it('emits resize-element with the new geometry after dragging the SE corner', async () => {
         const wrapper = mountTile()
         await dragHandle(wrapper, 'se', { x: 500, y: 500 }, { x: 700, y: 600 })

--- a/src/components/album.vue
+++ b/src/components/album.vue
@@ -28,7 +28,8 @@
             v-bind:token="token" v-on:imagefull="openImgFull" v-on:videofull="openVideoFull" v-bind:element-margin="elementMargin"
             v-bind:edit-mode="editMode" v-on:edit-text="onEditText"
             v-bind:is-last="index === pages.length - 1"
-            v-on:remove-element="onRemoveElement" v-on:add-image="onAddImage"
+            v-on:remove-element="onRemoveElement" v-on:resize-element="onResizeElement"
+            v-on:add-image="onAddImage"
             v-on:add-text="onAddText" v-on:cycle-layout="onCycleLayout"
             v-on:add-page="onAddPage" v-on:move-page="onMovePage"
             v-on:element-drop="onElementDrop">
@@ -77,7 +78,7 @@ import { NcLoadingIcon, NcActionInput, NcActionButton, NcActions, NcProgressBar,
 import Plus from 'vue-material-design-icons/Plus.vue'
 import JSZip from 'jszip'
 import { saveAs } from 'file-saver'
-import { setElementText, removeElement, buildImageElement, buildTextElement, buildPage, addElement, swapElements } from '../utils/albumEdit.js'
+import { setElementText, setElementGeometry, removeElement, buildImageElement, buildTextElement, buildPage, addElement, swapElements } from '../utils/albumEdit.js'
 import { isElementDrag } from '../utils/elementDrag.js'
 import { cycleLayout } from '../utils/tilePageLayout.js'
 import { updatePage, searchAsset, cleanAssets, createPage, deletePage, movePage } from '../api/albumApi.js'
@@ -420,6 +421,19 @@ export default {
                 .catch(error => {
                     showError(t("souvenirs","Could not remove the image."));
                 });
+        },
+        onResizeElement: function(pageId, elementId, geometry) {
+            // Patch only the resized element's geometry (preserving every other
+            // album/page/element field), then persist that page.
+            var index = this.pages.findIndex(p => p.id === pageId);
+            if (index < 0) {
+                return;
+            }
+            var updatedPage = setElementGeometry(this.pages[index], elementId, geometry);
+            this.pages.splice(index, 1, updatedPage);
+            updatePage(this.albumId, updatedPage).catch(error => {
+                showError(t("souvenirs","Could not resize the element."));
+            });
         },
         onCycleLayout: function(pageId) {
             // Switch the page to the next layout available for its element count.

--- a/src/components/page.vue
+++ b/src/components/page.vue
@@ -14,7 +14,7 @@
                 v-bind:s-video="element.video" v-bind:is-focus="isFocus"
                 v-on:imagefull="openImgFull" v-on:videofull="openVideoFull"
                 v-bind:edit-mode="editMode" v-on:edit-text="onEditText"
-                v-on:remove-element="onRemoveElement"
+                v-on:remove-element="onRemoveElement" v-on:resize-element="onResizeElement"
                 v-bind:s-page-id="sId" v-on:element-drop="onElementDrop"
                 v-bind:element-margin="elementMargin">
 	</selement>
@@ -149,6 +149,10 @@ export default {
       onRemoveElement: function(elementId) {
         // Re-emit with this page's id (sId) so the album can locate the element.
         this.$emit("remove-element", this.sId, elementId);
+      },
+      onResizeElement: function(elementId, geometry) {
+        // Re-emit with this page's id (sId) so the album can locate the element.
+        this.$emit("resize-element", this.sId, elementId, geometry);
       },
       onElementDrop: function(srcPageId, srcElementId, destElementId) {
         // Drop landed on one of this page's elements: re-emit with this page as

--- a/src/components/selement.vue
+++ b/src/components/selement.vue
@@ -7,7 +7,7 @@
     v-on:dragstart="onDragStart" v-on:dragend="onDragEnd"
     v-on:dragenter="onDragEnter" v-on:dragleave="onDragLeave"
     v-on:dragover="onDragOver" v-on:drop="onDrop"
-    v-bind:style="'top:'+(sTop+elementMargin).toString()+'%;left:'+(sLeft+elementMargin).toString()+'%;width:'+(sRight-sLeft-2*elementMargin).toString()+'%;height:'+(sBottom-sTop-2*elementMargin).toString()+'%;--image-src-url:url(\''+ sImageSrc +'\')'">
+    v-bind:style="rootStyle">
 		<button v-if="editMode && isRemovable" class="s-element-delete" :title="removeTitle" v-on:click.stop="onRemove">
 			<Delete :size="20" />
 		</button>
@@ -17,6 +17,15 @@
 				<CursorMove :size="20" />
 			</template>
 		</NcButton>
+		<template v-if="isResizable">
+			<div v-for="corner in resizeCorners" v-bind:key="'resize-'+corner"
+				v-bind:class="['s-element-resize-handle', 's-element-resize-handle--'+corner]"
+				:title="sDragToResize"
+				v-on:pointerdown="onResizeStart($event, corner)"
+				v-on:pointermove="onResizeMove"
+				v-on:pointerup="onResizeEnd"
+				v-on:pointercancel="onResizeCancel"></div>
+		</template>
 		<EditableText v-if="sText || editMode" class="s-element-text resize"
 			:value="sText" :editable="editMode" :auto-fit="true"
 			@save="onTextSave" />
@@ -105,6 +114,14 @@ export default {
             // suppresses caret placement / text selection in the contenteditable.
             "dragSuppressed": false,
             "sDragToMove": t("souvenirs","Drag to move"),
+            "sDragToResize": t("souvenirs","Drag to resize"),
+            "resizeCorners": ['nw', 'ne', 'sw', 'se'],
+            // State of the corner drag in progress (pointer id, start position,
+            // page size in px, original geometry), null when not resizing.
+            "resizing": null,
+            // Geometry shown while a corner is being dragged; the committed
+            // props (sTop/...) take over again once the resize is released.
+            "resizePreview": null,
             // dragenter/dragleave also fire when moving over children, so the
             // drag-over highlight is tracked with an enter/leave counter.
             "dragOverCount": 0,
@@ -210,6 +227,22 @@ export default {
             // and unknown elements have no visual box to grab).
             return this.editMode && this.isRemovable;
         },
+        'isResizable': function() {
+            // Any tile that can be dragged can also be resized (issue #20).
+            return this.isDraggable;
+        },
+        'displayGeometry': function() {
+            // Live preview while a corner is being dragged, committed props otherwise.
+            return this.resizePreview != null ? this.resizePreview
+                : { top: this.sTop, bottom: this.sBottom, left: this.sLeft, right: this.sRight };
+        },
+        'rootStyle': function() {
+            var g = this.displayGeometry;
+            return 'top:' + (g.top + this.elementMargin) + '%;left:' + (g.left + this.elementMargin)
+                + '%;width:' + (g.right - g.left - 2 * this.elementMargin)
+                + '%;height:' + (g.bottom - g.top - 2 * this.elementMargin)
+                + "%;--image-src-url:url('" + this.sImageSrc + "')";
+        },
         'removeTitle': function() {
             return (this.sClass != null && this.sClass.endsWith('TextElement'))
                 ? t("souvenirs","Remove text")
@@ -313,8 +346,69 @@ export default {
                 this.$refs.eldiv.setAttribute("draggable", String(this.isDraggable && !this.dragSuppressed));
             }
         },
+        onResizeStart: function(event, corner) {
+            if (!this.isResizable || this.resizing != null) {
+                return;
+            }
+            // The press belongs to the resize: keep it from starting an HTML5
+            // drag of the tile and from reaching onRootMouseDown.
+            event.preventDefault();
+            event.stopPropagation();
+            var page = this.$refs.eldiv ? this.$refs.eldiv.parentElement : null;
+            if (page == null) {
+                return;
+            }
+            // Element geometry is in page percentages, so pointer deltas are
+            // converted against the page box (the element's positioned parent).
+            var rect = page.getBoundingClientRect();
+            if (rect.width <= 0 || rect.height <= 0) {
+                return;
+            }
+            this.resizing = {
+                corner: corner,
+                pointerId: event.pointerId,
+                startX: event.clientX,
+                startY: event.clientY,
+                pageWidth: rect.width,
+                pageHeight: rect.height,
+                orig: { top: this.sTop, bottom: this.sBottom, left: this.sLeft, right: this.sRight },
+            };
+            // Route the whole gesture to the handle, even when the pointer
+            // leaves it (or the element) while dragging.
+            if (event.target.setPointerCapture) {
+                event.target.setPointerCapture(event.pointerId);
+            }
+        },
+        onResizeMove: function(event) {
+            if (this.resizing == null || event.pointerId !== this.resizing.pointerId) {
+                return;
+            }
+            this.resizePreview = resizedGeometry(this.resizing, event.clientX, event.clientY);
+        },
+        onResizeEnd: function(event) {
+            if (this.resizing == null || event.pointerId !== this.resizing.pointerId) {
+                return;
+            }
+            var geometry = resizedGeometry(this.resizing, event.clientX, event.clientY);
+            var orig = this.resizing.orig;
+            this.resizing = null;
+            this.resizePreview = null;
+            if (geometry.top !== orig.top || geometry.bottom !== orig.bottom
+                || geometry.left !== orig.left || geometry.right !== orig.right) {
+                // Bubble the new geometry up with this element's id so the
+                // album can patch and persist it (sId is the element id here).
+                this.$emit("resize-element", this.sId, geometry);
+            }
+        },
+        onResizeCancel: function(event) {
+            if (this.resizing == null || event.pointerId !== this.resizing.pointerId) {
+                return;
+            }
+            this.resizing = null;
+            this.resizePreview = null;
+        },
         onDragStart: function(event) {
-            if (!this.isDraggable || this.dragSuppressed) {
+            if (!this.isDraggable || this.dragSuppressed || this.resizing != null) {
                 event.preventDefault();
                 return;
             }
@@ -406,6 +500,44 @@ function getImageZoomOffsetStyle(zoom, offsetX, offsetY, destWidth, destHeight, 
     return style;
 }
 
+// Tiles cannot be resized below this, so the corner handles stay grabbable
+// (in page percentages, i.e. 5% of the page side).
+const MIN_ELEMENT_SIZE_PCT = 5;
+
+// Geometry (in page percentages) of an ongoing corner resize: the two edges
+// meeting at the grabbed corner follow the pointer, clamped to the page bounds
+// and to the minimum tile size; the opposite edges stay put.
+function resizedGeometry(resizing, clientX, clientY) {
+    var dx = (clientX - resizing.startX) * 100 / resizing.pageWidth;
+    var dy = (clientY - resizing.startY) * 100 / resizing.pageHeight;
+    var g = {
+        top: resizing.orig.top,
+        bottom: resizing.orig.bottom,
+        left: resizing.orig.left,
+        right: resizing.orig.right,
+    };
+    if (resizing.corner === 'nw' || resizing.corner === 'ne') {
+        g.top = clampPct(resizing.orig.top + dy, 0, g.bottom - MIN_ELEMENT_SIZE_PCT);
+    } else {
+        g.bottom = clampPct(resizing.orig.bottom + dy, g.top + MIN_ELEMENT_SIZE_PCT, 100);
+    }
+    if (resizing.corner === 'nw' || resizing.corner === 'sw') {
+        g.left = clampPct(resizing.orig.left + dx, 0, g.right - MIN_ELEMENT_SIZE_PCT);
+    } else {
+        g.right = clampPct(resizing.orig.right + dx, g.left + MIN_ELEMENT_SIZE_PCT, 100);
+    }
+    return g;
+}
+
+function clampPct(value, min, max) {
+    if (max < min) {
+        // A tile already smaller than the minimum (e.g. hand-written album.json)
+        // can only grow, never shrink further.
+        max = min;
+    }
+    return Math.round(Math.min(Math.max(value, min), max) * 100) / 100;
+}
+
 function basename(path) {
    return path.split('/').reverse()[0];
 }
@@ -452,6 +584,34 @@ function basename(path) {
 .s-element-drag-handle :deep(*) {
 	cursor: grab;
 }
+
+/* Corner resize handles (edit mode). Above the drag/delete buttons (z 8) so
+   the small overlap in the top corners resolves to the resize cursor; inside
+   the tile because .s-element clips its overflow. touch-action:none keeps the
+   browser from turning the pointer gesture into a scroll on touch screens. */
+.s-element-resize-handle {
+	position: absolute;
+	width: 16px;
+	height: 16px;
+	z-index: 9;
+	/* The element wrapper disables pointer events; handles must opt back in. */
+	pointer-events: all;
+	touch-action: none;
+	background-color: var(--color-primary-element, #0082c9);
+	border: 2px solid var(--color-primary-element-text, #ffffff);
+	border-radius: 3px;
+	box-shadow: 0 1px 4px rgba(0, 0, 0, 0.4);
+	opacity: 0.9;
+}
+
+.s-element-resize-handle:hover {
+	opacity: 1;
+}
+
+.s-element-resize-handle--nw { top: 0; left: 0; cursor: nwse-resize; }
+.s-element-resize-handle--ne { top: 0; right: 0; cursor: nesw-resize; }
+.s-element-resize-handle--sw { bottom: 0; left: 0; cursor: nesw-resize; }
+.s-element-resize-handle--se { bottom: 0; right: 0; cursor: nwse-resize; }
 
 /* Valid drop target under the dragged tile. Inset dashed frame (the tile clips
    its overflow, so an offset outline would be cut on the page edges). */

--- a/src/components/selement.vue
+++ b/src/components/selement.vue
@@ -223,9 +223,14 @@ export default {
                 || this.sClass.endsWith('TextElement'));
         },
         'isDraggable': function() {
-            // The same visible tiles that can be removed can be dragged (Audio
-            // and unknown elements have no visual box to grab).
-            return this.editMode && this.isRemovable;
+            // The visible tiles that can be removed can be dragged (Audio and
+            // unknown elements have no visual box to grab) — except paint
+            // elements, which are static foregrounds: they keep their position
+            // (as in the page layouts) and never move or resize. Not being
+            // draggable also keeps them pointer-transparent, so they cannot be
+            // a drop target either.
+            return this.editMode && this.isRemovable
+                && !this.sClass.endsWith('PaintElement');
         },
         'isResizable': function() {
             // Any tile that can be dragged can also be resized (issue #20).

--- a/src/utils/__tests__/albumEdit.test.js
+++ b/src/utils/__tests__/albumEdit.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { setElementText, relayoutElements, removeElement, buildImageElement, buildTextElement, buildPage, addElement, swapElements } from '../albumEdit.js'
+import { setElementText, setElementGeometry, relayoutElements, removeElement, buildImageElement, buildTextElement, buildPage, addElement, swapElements } from '../albumEdit.js'
 
 describe('setElementText', () => {
     const makePage = () => ({
@@ -310,5 +310,74 @@ describe('addElement', () => {
         const page = { id: 'p', elements: [] }
         addElement(page, buildImageElement({ name: 'b.jpg', size: 2, mime: 'image/jpeg' }))
         expect(page.elements).toHaveLength(0)
+    })
+})
+
+describe('setElementGeometry', () => {
+    const makePage = () => ({
+        id: 'page-1',
+        // A field this app does not know about — must survive editing.
+        customPageField: 'keep-me',
+        elements: [
+            {
+                id: 'el-1',
+                class: 'ImageElement',
+                image: 'data/a.jpg',
+                text: 'caption',
+                top: 0,
+                left: 0,
+                right: 100,
+                bottom: 50,
+                zoom: 120,
+                // Unknown per-element field that must be preserved.
+                androidOnlyField: 42,
+            },
+            {
+                id: 'el-2',
+                class: 'TextElement',
+                top: 50,
+                left: 0,
+                right: 100,
+                bottom: 100,
+            },
+        ],
+    })
+
+    it('replaces only the targeted element geometry', () => {
+        const result = setElementGeometry(makePage(), 'el-1', { top: 10, left: 20, right: 80, bottom: 40 })
+        expect(result.elements[0]).toMatchObject({ top: 10, left: 20, right: 80, bottom: 40 })
+        expect(result.elements[1]).toMatchObject({ top: 50, left: 0, right: 100, bottom: 100 })
+    })
+
+    it('preserves all other element fields, including unknown ones', () => {
+        const result = setElementGeometry(makePage(), 'el-1', { top: 10, left: 20, right: 80, bottom: 40 })
+        const resized = result.elements[0]
+        expect(resized.image).toBe('data/a.jpg')
+        expect(resized.text).toBe('caption')
+        expect(resized.zoom).toBe(120)
+        expect(resized.androidOnlyField).toBe(42)
+    })
+
+    it('preserves unknown page-level fields and the full elements set', () => {
+        const result = setElementGeometry(makePage(), 'el-1', { top: 10, left: 20, right: 80, bottom: 40 })
+        expect(result.id).toBe('page-1')
+        expect(result.customPageField).toBe('keep-me')
+        expect(result.elements).toHaveLength(2)
+    })
+
+    it('does not mutate the original page or its elements', () => {
+        const page = makePage()
+        setElementGeometry(page, 'el-1', { top: 10, left: 20, right: 80, bottom: 40 })
+        expect(page.elements[0]).toMatchObject({ top: 0, left: 0, right: 100, bottom: 50 })
+    })
+
+    it('is a no-op when the element id is not found', () => {
+        const result = setElementGeometry(makePage(), 'missing', { top: 10, left: 20, right: 80, bottom: 40 })
+        expect(result.elements[0]).toMatchObject({ top: 0, left: 0, right: 100, bottom: 50 })
+        expect(result.elements[1]).toMatchObject({ top: 50, left: 0, right: 100, bottom: 100 })
+    })
+
+    it('tolerates a page without an elements array', () => {
+        expect(setElementGeometry({ id: 'p' }, 'el-1', { top: 0, left: 0, right: 100, bottom: 100 }).elements).toEqual([])
     })
 })

--- a/src/utils/albumEdit.js
+++ b/src/utils/albumEdit.js
@@ -155,6 +155,29 @@ export function swapElements(page, elementIdA, elementIdB) {
 
 /**
  * Return a copy of `page` in which the element identified by `elementId` has its
+ * geometry (top/left/right/bottom, in page percentages) replaced. All other fields
+ * of the page and of every element (including ones this app does not know about)
+ * are preserved untouched. Used by the corner-handle resize (issue #20).
+ *
+ * @param {object} page - a page object, expected to contain an `elements` array
+ * @param {string} elementId - the `id` of the element being resized
+ * @param {{top: number, left: number, right: number, bottom: number}} geometry
+ * @returns {object} a new page object with the single change applied
+ */
+export function setElementGeometry(page, elementId, { top, left, right, bottom }) {
+    const elements = Array.isArray(page.elements) ? page.elements : []
+    return {
+        ...page,
+        elements: elements.map(element =>
+            element.id === elementId
+                ? { ...element, top, left, right, bottom }
+                : element,
+        ),
+    }
+}
+
+/**
+ * Return a copy of `page` in which the element identified by `elementId` has its
  * `text` set to `newText`. All other fields of the page and of every element
  * (including ones this app does not know about) are preserved untouched.
  *

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -11,5 +11,12 @@ export default defineConfig({
         setupFiles: ['./tests/frontend/setup.js'],
         include: ['src/**/*.{test,spec}.js'],
         globals: true,
+        server: {
+            deps: {
+                // @nextcloud/vue ships ESM that imports its own .css assets;
+                // inline it so Vite transforms those imports during tests.
+                inline: [/@nextcloud\/vue/],
+            },
+        },
     },
 })


### PR DESCRIPTION
Closes #20.

In edit mode, every tile that can be dragged (image, video, text) now shows four corner handles. Dragging a handle resizes the element with a live preview: the two edges meeting at the grabbed corner follow the pointer, clamped to the page bounds and to a 5% minimum size. On release, the new geometry is persisted through the existing page update API, patching only the resized element's `top`/`left`/`right`/`bottom` so every other (possibly unknown) field of `album.json` is preserved.

### Implementation

- **`selement.vue`** — corner handles rendered for resizable tiles, pointer-event gesture with pointer capture (touch works too via `touch-action: none`), live-preview geometry overriding the committed props while dragging, and guards so a resize never triggers the HTML5 tile drag from #18. Emits `resize-element` only when the geometry actually changed; `pointercancel` snaps back.
- **`page.vue` / `album.vue`** — relay the event with the page id, patch via a new pure helper, persist with `updatePage` (error toast on failure).
- **`albumEdit.js`** — new `setElementGeometry(page, elementId, geometry)` helper, following the same preserve-unknown-fields contract as the other edit helpers.
- **Paint elements stay static**: they are foregrounds that keep their position (as in the page layouts), so they get no drag handle, no resize handles, and cannot be a drop target. Deleting them is still possible.

### Tests

- 7 unit tests for `setElementGeometry`.
- New component suite `selement.resize.test.js` (8 tests) simulating full pointer gestures: per-corner geometry, bounds/min-size clamping, live preview, cancel, no-op drags, no handles outside edit mode / on audio, and static paint elements.
- `vitest.config.js` now inlines `@nextcloud/vue` (it imports its own CSS) so component tests can mount `selement.vue`.

All 94 tests pass; `npm run build` succeeds.