### PR TITLE
Pan and zoom image elements in edit mode

### DIFF
--- a/src/components/__tests__/selement.panzoom.test.js
+++ b/src/components/__tests__/selement.panzoom.test.js
@@ -1,0 +1,240 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import Selement from '../selement.vue'
+import { ELEMENT_DRAG_TYPE } from '../../utils/elementDrag.js'
+
+// Mount an image tile with a fake 500x500px box and a loaded 2000x2000 image
+// (square image in a square box: cover-fit fills the box exactly, so expected
+// offsets are easy to derive: 1px of pan = 0.2% at zoom 100).
+async function mountImageTile(props = {}) {
+    const wrapper = mount(Selement, {
+        attachTo: document.body,
+        props: {
+            sId: 'el-1',
+            sPageId: 'page-1',
+            editMode: true,
+            sClass: 'ImageElement',
+            sImage: 'photo.jpg',
+            sText: '',
+            sTop: 0,
+            sBottom: 50,
+            sLeft: 0,
+            sRight: 50,
+            sZoom: 100,
+            sOffsetX: 0,
+            sOffsetY: 0,
+            sTransformType: 2,
+            albumPath: 'Souvenirs/test',
+            token: '',
+            preload: false,
+            // Pan & zoom only works on the currently displayed page.
+            isFocus: true,
+            elementMargin: 1,
+            ...props,
+        },
+    })
+    // happy-dom has no layout: give the element box a concrete size, and inject
+    // the "loaded image" natural size the gesture math needs.
+    wrapper.element.getBoundingClientRect = () => ({
+        width: 500, height: 500, top: 0, left: 0, right: 500, bottom: 500, x: 0, y: 0,
+    })
+    wrapper.vm.imgSize = { width: 2000, height: 2000 }
+    await wrapper.vm.$nextTick()
+    return wrapper
+}
+
+function img(wrapper) {
+    return wrapper.find('img.image-element')
+}
+
+afterEach(() => {
+    vi.useRealTimers()
+})
+
+describe('selement image pan & zoom (edit mode)', () => {
+    it('pans with a pointer drag and emits the new offsets on release', async () => {
+        const wrapper = await mountImageTile()
+        await img(wrapper).trigger('pointerdown', { pointerId: 1, clientX: 100, clientY: 100 })
+        await img(wrapper).trigger('pointermove', { pointerId: 1, clientX: 150, clientY: 120 })
+        // Live preview, nothing committed yet: the image moved 50px right, 20px
+        // down (10% / 4% of the box).
+        expect(wrapper.emitted('pan-zoom-element')).toBeFalsy()
+        expect(wrapper.vm.imageStyle.transform).toContain('translate(50px,20px)')
+        await img(wrapper).trigger('pointerup', { pointerId: 1, clientX: 150, clientY: 120 })
+        expect(wrapper.emitted('pan-zoom-element')).toEqual([
+            ['el-1', { zoom: 100, offsetX: 10, offsetY: 4, transformType: 2 }],
+        ])
+    })
+
+    it('reverts to the committed values when the gesture is cancelled', async () => {
+        const wrapper = await mountImageTile()
+        await img(wrapper).trigger('pointerdown', { pointerId: 1, clientX: 100, clientY: 100 })
+        await img(wrapper).trigger('pointermove', { pointerId: 1, clientX: 200, clientY: 100 })
+        await img(wrapper).trigger('pointercancel', { pointerId: 1 })
+        expect(wrapper.emitted('pan-zoom-element')).toBeFalsy()
+        expect(wrapper.vm.panZoomPreview).toBe(null)
+    })
+
+    it('does not emit for a click without movement', async () => {
+        const wrapper = await mountImageTile({ sTransformType: 1 })
+        await img(wrapper).trigger('pointerdown', { pointerId: 1, clientX: 100, clientY: 100 })
+        await img(wrapper).trigger('pointerup', { pointerId: 1, clientX: 100, clientY: 100 })
+        expect(wrapper.emitted('pan-zoom-element')).toBeFalsy()
+    })
+
+    it('zooms with the mouse wheel about the cursor and commits after a pause', async () => {
+        vi.useFakeTimers()
+        const wrapper = await mountImageTile()
+        // One notch up at the box center: zoom * e^0.2, center kept fixed.
+        await img(wrapper).trigger('wheel', { deltaY: -100, clientX: 250, clientY: 250 })
+        expect(wrapper.emitted('pan-zoom-element')).toBeFalsy()
+        vi.advanceTimersByTime(500)
+        const emitted = wrapper.emitted('pan-zoom-element')
+        expect(emitted).toHaveLength(1)
+        expect(emitted[0][0]).toBe('el-1')
+        expect(emitted[0][1].zoom).toBeCloseTo(122.14, 2)
+        expect(emitted[0][1].offsetX).toBeCloseTo(-9.06, 2)
+        expect(emitted[0][1].offsetY).toBeCloseTo(-9.06, 2)
+        expect(emitted[0][1].transformType).toBe(2)
+    })
+
+    it('accumulates successive wheel notches into one commit', async () => {
+        vi.useFakeTimers()
+        const wrapper = await mountImageTile()
+        await img(wrapper).trigger('wheel', { deltaY: -100, clientX: 0, clientY: 0 })
+        await img(wrapper).trigger('wheel', { deltaY: -100, clientX: 0, clientY: 0 })
+        vi.advanceTimersByTime(500)
+        const emitted = wrapper.emitted('pan-zoom-element')
+        expect(emitted).toHaveLength(1)
+        // Top-left anchor: pure zoom, e^0.2 twice.
+        expect(emitted[0][1].zoom).toBeCloseTo(149.18, 2)
+        expect(emitted[0][1].offsetX).toBe(0)
+    })
+
+    it('pinch-zooms with two pointers', async () => {
+        const wrapper = await mountImageTile()
+        await img(wrapper).trigger('pointerdown', { pointerId: 1, clientX: 200, clientY: 200 })
+        await img(wrapper).trigger('pointerdown', { pointerId: 2, clientX: 300, clientY: 200 })
+        // Spread the fingers to double the distance around a fixed midpoint.
+        await img(wrapper).trigger('pointermove', { pointerId: 1, clientX: 150, clientY: 200 })
+        await img(wrapper).trigger('pointermove', { pointerId: 2, clientX: 350, clientY: 200 })
+        await img(wrapper).trigger('pointerup', { pointerId: 1, clientX: 150, clientY: 200 })
+        await img(wrapper).trigger('pointerup', { pointerId: 2, clientX: 350, clientY: 200 })
+        expect(wrapper.emitted('pan-zoom-element')).toEqual([
+            ['el-1', { zoom: 200, offsetX: -25, offsetY: -20, transformType: 2 }],
+        ])
+    })
+
+    it('switches a center-crop element to zoom-offset on the first pan', async () => {
+        const wrapper = await mountImageTile({ sTransformType: 1, sZoom: 0 })
+        await img(wrapper).trigger('pointerdown', { pointerId: 1, clientX: 100, clientY: 100 })
+        await img(wrapper).trigger('pointermove', { pointerId: 1, clientX: 150, clientY: 100 })
+        await img(wrapper).trigger('pointerup', { pointerId: 1, clientX: 150, clientY: 100 })
+        expect(wrapper.emitted('pan-zoom-element')).toEqual([
+            ['el-1', { zoom: 100, offsetX: 10, offsetY: 0, transformType: 2 }],
+        ])
+    })
+
+    it('ignores gestures outside edit mode', async () => {
+        const wrapper = await mountImageTile({ editMode: false })
+        await img(wrapper).trigger('pointerdown', { pointerId: 1, clientX: 100, clientY: 100 })
+        await img(wrapper).trigger('pointermove', { pointerId: 1, clientX: 200, clientY: 200 })
+        await img(wrapper).trigger('pointerup', { pointerId: 1, clientX: 200, clientY: 200 })
+        await img(wrapper).trigger('wheel', { deltaY: -100, clientX: 0, clientY: 0 })
+        expect(wrapper.emitted('pan-zoom-element')).toBeFalsy()
+        expect(wrapper.vm.panZoomPreview).toBe(null)
+    })
+
+    it('ignores gestures on a page that is not the displayed one', async () => {
+        // A touch drag over a peeking neighbor page must scroll the album, not
+        // pan its images: no pan class (touch-action) and no gesture handling.
+        const wrapper = await mountImageTile({ isFocus: false })
+        expect(img(wrapper).classes()).not.toContain('image-element--pan')
+        await img(wrapper).trigger('pointerdown', { pointerId: 1, clientX: 100, clientY: 100 })
+        await img(wrapper).trigger('pointermove', { pointerId: 1, clientX: 200, clientY: 200 })
+        await img(wrapper).trigger('pointerup', { pointerId: 1, clientX: 200, clientY: 200 })
+        await img(wrapper).trigger('wheel', { deltaY: -100, clientX: 0, clientY: 0 })
+        expect(wrapper.emitted('pan-zoom-element')).toBeFalsy()
+        expect(wrapper.vm.panZoomPreview).toBe(null)
+    })
+})
+
+describe('selement pan & zoom reset button', () => {
+    it('shows on image elements in edit mode only', async () => {
+        expect((await mountImageTile()).find('.s-element-pan-reset').exists()).toBe(true)
+        expect((await mountImageTile({ editMode: false })).find('.s-element-pan-reset').exists()).toBe(false)
+        expect((await mountImageTile({ sClass: 'TextElement', sImage: '' })).find('.s-element-pan-reset').exists()).toBe(false)
+    })
+
+    it('resets a panned/zoomed element to plain cover-fit', async () => {
+        const wrapper = await mountImageTile({ sZoom: 180, sOffsetX: 12, sOffsetY: -7 })
+        await wrapper.find('.s-element-pan-reset').trigger('click')
+        expect(wrapper.emitted('pan-zoom-element')).toEqual([
+            ['el-1', { zoom: 100, offsetX: 0, offsetY: 0, transformType: 2 }],
+        ])
+    })
+
+    it('converts a fill (contain) element to cover-fit', async () => {
+        const wrapper = await mountImageTile({ sTransformType: 0, sZoom: 0 })
+        await wrapper.find('.s-element-pan-reset').trigger('click')
+        expect(wrapper.emitted('pan-zoom-element')).toEqual([
+            ['el-1', { zoom: 100, offsetX: 0, offsetY: 0, transformType: 2 }],
+        ])
+    })
+
+    it('does not persist anything when the element already renders as cover-fit', async () => {
+        // Zoom-offset at the defaults, and center-crop (the same rendering).
+        const zoomOffset = await mountImageTile()
+        await zoomOffset.find('.s-element-pan-reset').trigger('click')
+        expect(zoomOffset.emitted('pan-zoom-element')).toBeFalsy()
+        const centerCrop = await mountImageTile({ sTransformType: 1, sZoom: 0 })
+        await centerCrop.find('.s-element-pan-reset').trigger('click')
+        expect(centerCrop.emitted('pan-zoom-element')).toBeFalsy()
+    })
+
+    it('discards a pending wheel preview instead of committing it', async () => {
+        vi.useFakeTimers()
+        const wrapper = await mountImageTile()
+        await img(wrapper).trigger('wheel', { deltaY: -100, clientX: 250, clientY: 250 })
+        await wrapper.find('.s-element-pan-reset').trigger('click')
+        vi.advanceTimersByTime(1000)
+        expect(wrapper.emitted('pan-zoom-element')).toBeFalsy()
+        expect(wrapper.vm.panZoomPreview).toBe(null)
+    })
+})
+
+describe('selement caption editor scope', () => {
+    it('shows no caption field on an image element without text', async () => {
+        const wrapper = await mountImageTile()
+        expect(wrapper.find('.s-element-text').exists()).toBe(false)
+    })
+
+    it('shows an existing image caption read-only in edit mode', async () => {
+        const wrapper = await mountImageTile({ sText: 'a memory' })
+        const caption = wrapper.find('.s-element-text')
+        expect(caption.exists()).toBe(true)
+        expect(caption.classes()).not.toContain('editable-text--editing')
+    })
+
+    it('keeps the caption editable on text elements', async () => {
+        const wrapper = await mountImageTile({ sClass: 'TextElement', sImage: '', sText: '' })
+        const caption = wrapper.find('.s-element-text')
+        expect(caption.exists()).toBe(true)
+        expect(caption.classes()).toContain('editable-text--editing')
+    })
+})
+
+describe('selement drag handle (move to another page)', () => {
+    it('starts the element drag from the handle with the element payload', async () => {
+        const wrapper = await mountImageTile()
+        const dataTransfer = { setData: vi.fn(), setDragImage: vi.fn(), effectAllowed: '' }
+        await wrapper.find('.s-element-drag-handle').trigger('dragstart', { dataTransfer })
+        expect(dataTransfer.setData).toHaveBeenCalledWith(
+            ELEMENT_DRAG_TYPE,
+            JSON.stringify({ pageId: 'page-1', elementId: 'el-1' }),
+        )
+        expect(dataTransfer.effectAllowed).toBe('move')
+        // The whole tile is shown in flight, not just the handle button.
+        expect(dataTransfer.setDragImage).toHaveBeenCalledWith(wrapper.element, expect.any(Number), expect.any(Number))
+    })
+})

--- a/src/components/__tests__/selement.resize.test.js
+++ b/src/components/__tests__/selement.resize.test.js
@@ -55,13 +55,20 @@ describe('selement corner resize', () => {
         expect(mountTile({ sClass: 'AudioElement' }).findAll('.s-element-resize-handle')).toHaveLength(0)
     })
 
-    it('keeps paint elements static: no resize handles, no drag handle, not draggable', () => {
+    it('keeps paint elements static: no resize handles, no drag handle', () => {
         const wrapper = mountTile({ sClass: 'PaintElement' })
         expect(wrapper.findAll('.s-element-resize-handle')).toHaveLength(0)
         expect(wrapper.find('.s-element-drag-handle').exists()).toBe(false)
-        expect(wrapper.attributes('draggable')).toBe('false')
         // Still removable: the delete button stays.
         expect(wrapper.find('.s-element-delete').exists()).toBe(true)
+    })
+
+    it('never marks the tile itself as an HTML5 drag source (handle-only drags)', () => {
+        // Moving an element grabs the handle button; the tile surface is
+        // reserved for the pan & zoom gestures (issue #27).
+        const wrapper = mountTile()
+        expect(wrapper.attributes('draggable')).toBeUndefined()
+        expect(wrapper.find('.s-element-drag-handle').attributes('draggable')).toBe('true')
     })
 
     it('emits resize-element with the new geometry after dragging the SE corner', async () => {

--- a/src/components/album.vue
+++ b/src/components/album.vue
@@ -29,6 +29,7 @@
             v-bind:edit-mode="editMode" v-on:edit-text="onEditText"
             v-bind:is-last="index === pages.length - 1"
             v-on:remove-element="onRemoveElement" v-on:resize-element="onResizeElement"
+            v-on:pan-zoom-element="onPanZoomElement"
             v-on:add-image="onAddImage"
             v-on:add-text="onAddText" v-on:cycle-layout="onCycleLayout"
             v-on:add-page="onAddPage" v-on:move-page="onMovePage"
@@ -78,7 +79,7 @@ import { NcLoadingIcon, NcActionInput, NcActionButton, NcActions, NcProgressBar,
 import Plus from 'vue-material-design-icons/Plus.vue'
 import JSZip from 'jszip'
 import { saveAs } from 'file-saver'
-import { setElementText, setElementGeometry, removeElement, buildImageElement, buildTextElement, buildPage, addElement, swapElements } from '../utils/albumEdit.js'
+import { setElementText, setElementGeometry, setElementPanZoom, removeElement, buildImageElement, buildTextElement, buildPage, addElement, swapElements } from '../utils/albumEdit.js'
 import { isElementDrag } from '../utils/elementDrag.js'
 import { cycleLayout } from '../utils/tilePageLayout.js'
 import { updatePage, searchAsset, cleanAssets, createPage, deletePage, movePage } from '../api/albumApi.js'
@@ -433,6 +434,19 @@ export default {
             this.pages.splice(index, 1, updatedPage);
             updatePage(this.albumId, updatedPage).catch(error => {
                 showError(t("souvenirs","Could not resize the element."));
+            });
+        },
+        onPanZoomElement: function(pageId, elementId, panZoom) {
+            // Patch only the panned/zoomed element's values (preserving every
+            // other album/page/element field), then persist that page.
+            var index = this.pages.findIndex(p => p.id === pageId);
+            if (index < 0) {
+                return;
+            }
+            var updatedPage = setElementPanZoom(this.pages[index], elementId, panZoom);
+            this.pages.splice(index, 1, updatedPage);
+            updatePage(this.albumId, updatedPage).catch(error => {
+                showError(t("souvenirs","Could not adjust the image."));
             });
         },
         onCycleLayout: function(pageId) {

--- a/src/components/page.vue
+++ b/src/components/page.vue
@@ -15,6 +15,7 @@
                 v-on:imagefull="openImgFull" v-on:videofull="openVideoFull"
                 v-bind:edit-mode="editMode" v-on:edit-text="onEditText"
                 v-on:remove-element="onRemoveElement" v-on:resize-element="onResizeElement"
+                v-on:pan-zoom-element="onPanZoomElement"
                 v-bind:s-page-id="sId" v-on:element-drop="onElementDrop"
                 v-bind:element-margin="elementMargin">
 	</selement>
@@ -153,6 +154,10 @@ export default {
       onResizeElement: function(elementId, geometry) {
         // Re-emit with this page's id (sId) so the album can locate the element.
         this.$emit("resize-element", this.sId, elementId, geometry);
+      },
+      onPanZoomElement: function(elementId, panZoom) {
+        // Re-emit with this page's id (sId) so the album can locate the element.
+        this.$emit("pan-zoom-element", this.sId, elementId, panZoom);
       },
       onElementDrop: function(srcPageId, srcElementId, destElementId) {
         // Drop landed on one of this page's elements: re-emit with this page as

--- a/src/components/selement.vue
+++ b/src/components/selement.vue
@@ -1,20 +1,29 @@
 <template>
-    <div ref="eldiv" v-bind:class="['s-element', ((sClass.endsWith('ImageElement') || sClass.endsWith('VideoElement')) && sZoom < 100) ? 'blur-back' : '',
+    <div ref="eldiv" v-bind:class="['s-element', ((sClass.endsWith('ImageElement') || sClass.endsWith('VideoElement')) && effectiveZoom < 100) ? 'blur-back' : '',
     { 's-element--draggable': isDraggable, 's-element--dragging': isDragging, 's-element--dragover': isDragOver }]"
     v-bind:id="sId"
-    v-bind:draggable="isDraggable && !dragSuppressed"
-    v-on:mousedown="onRootMouseDown"
-    v-on:dragstart="onDragStart" v-on:dragend="onDragEnd"
     v-on:dragenter="onDragEnter" v-on:dragleave="onDragLeave"
     v-on:dragover="onDragOver" v-on:drop="onDrop"
     v-bind:style="rootStyle">
 		<button v-if="editMode && isRemovable" class="s-element-delete" :title="removeTitle" v-on:click.stop="onRemove">
 			<Delete :size="20" />
 		</button>
+		<!-- The handle is the only drag source for moving the element to another
+		     page/slot (issue #27): the tile surface itself is reserved for the
+		     pan & zoom gestures on image elements. -->
 		<NcButton v-if="isDraggable" class="s-element-drag-handle" type="primary"
-			:aria-label="sDragToMove" :title="sDragToMove">
+			:aria-label="sDragToMove" :title="sDragToMove"
+			draggable="true" v-on:dragstart="onDragStart" v-on:dragend="onDragEnd">
 			<template #icon>
 				<CursorMove :size="20" />
+			</template>
+		</NcButton>
+		<!-- Back to the default framing (cover-fit: zoom 100, no offset) after
+		     pan & zoom gestures. -->
+		<NcButton v-if="editMode && sClass.endsWith('ImageElement')" class="s-element-pan-reset" type="primary"
+			:aria-label="sResetPanZoom" :title="sResetPanZoom" v-on:click="onPanZoomReset">
+			<template #icon>
+				<FitToScreen :size="20" />
 			</template>
 		</NcButton>
 		<template v-if="isResizable">
@@ -26,8 +35,11 @@
 				v-on:pointerup="onResizeEnd"
 				v-on:pointercancel="onResizeCancel"></div>
 		</template>
-		<EditableText v-if="sText || editMode" class="s-element-text resize"
-			:value="sText" :editable="editMode" :auto-fit="true"
+		<!-- Editing text is a TextElement-only affair: on other elements a
+		     stored caption is still displayed, but read-only (and click-through,
+		     so it does not block the pan & zoom gestures on the image below). -->
+		<EditableText v-if="sText || (editMode && isTextElement)" class="s-element-text resize"
+			:value="sText" :editable="editMode && isTextElement" :auto-fit="true"
 			@save="onTextSave" />
         <video v-bind:id="sId+'video'" v-if="sClass.endsWith('VideoElement')" v-on:click="openVideo"
             v-bind:class="['video-element', sZoom == 100 ? 'centercrop' : 'fill' ]" 
@@ -39,15 +51,19 @@
             <NcLoadingIcon :size="64"></NcLoadingIcon>
         </div>
         
-		<img id="image_element" v-bind:style="imageStyle" v-bind:class="['image-element', isImgCenterCrop ? 'centercrop' : '', isImgFill ? 'fill' : '' ]"
+		<img id="image_element" v-bind:style="imageStyle" v-bind:class="['image-element', isImgCenterCrop ? 'centercrop' : '', isImgFill ? 'fill' : '', canPanZoom ? 'image-element--pan' : '' ]"
         v-if="sImage != '' && (sClass.endsWith('ImageElement') || sClass.endsWith('VideoElement'))"
-        v-bind:src="sImageSrc" v-on:click="openImgFull" v-bind:draggable="!editMode" />
+        v-bind:src="sImageSrc" v-on:click="openImgFull" v-bind:draggable="!editMode"
+        v-on:pointerdown="onImagePointerDown" v-on:pointermove="onImagePointerMove"
+        v-on:pointerup="onImagePointerUp" v-on:pointercancel="onImagePointerCancel"
+        v-on:wheel="onImageWheel" />
         <img v-bind:class="['paint-element', isImgCenterCrop ? 'centercrop' : '', isImgFill ? 'fill' : '' ]" v-if="sImage != '' && sClass.endsWith('PaintElement')" v-bind:src="sImageSrc" v-bind:draggable="!editMode"/>
         <div v-if="sMime == 'application/vnd.google.panorama360+jpg'" class="image-element-pano-icon"/>
         <div v-if="sVideo != null" class="image-element-video-icon"/>
         <!-- In edit mode the tile takes pointer-events:all (drag and drop), which
-             would make this whole-tile overlay swallow clicks meant for the
-             caption editor below it: keep it click-through while editing. -->
+             would make this whole-tile overlay swallow the events meant for the
+             caption editor and the pan & zoom surface below it: keep it
+             click-through while editing. -->
         <div v-bind:id="'pano-'+sId" v-bind:style="'position:absolute;top:0;left:0;width: 100%;height: 100%;' + (editMode ? 'pointer-events:none;' : '')"/>
         <div v-if="isVideoLoading" class="center">
             <NcLoadingIcon :size="64">
@@ -73,7 +89,15 @@ import { imagePath } from '@nextcloud/router'
 import EditableText from './EditableText.vue'
 import Delete from 'vue-material-design-icons/Delete.vue'
 import CursorMove from 'vue-material-design-icons/CursorMove.vue'
+import FitToScreen from 'vue-material-design-icons/FitToScreen.vue'
 import { setElementDragData, isElementDrag, getElementDragData } from '../utils/elementDrag.js'
+import { initialPanZoom, panBy, zoomAt, roundPanZoom } from '../utils/imagePanZoom.js'
+
+// Zoom speed of the mouse wheel: multiplicative factor e^(-deltaY * this).
+// 0.002 gives ~±22% per classic 100-unit wheel notch.
+const WHEEL_ZOOM_SPEED = 0.002;
+// A wheel gesture has no end event: commit after this much wheel silence.
+const WHEEL_COMMIT_DELAY_MS = 500;
 
 export default {
     props: {
@@ -109,12 +133,16 @@ export default {
             "isVideoLoading": false,
             "isDragging": false,
             "isDragOver": false,
-            // True while the current press started inside the caption editor:
-            // the tile must not be draggable then, otherwise the browser
-            // suppresses caret placement / text selection in the contenteditable.
-            "dragSuppressed": false,
+            // Natural size of the loaded image, needed by the zoom/offset
+            // transform and by the pan & zoom gesture math.
+            "imgSize": null,
+            // Pan & zoom values shown while a gesture is in progress (or a
+            // wheel commit is pending); the committed props take over when
+            // null. Always rendered as the zoom-offset transform type.
+            "panZoomPreview": null,
             "sDragToMove": t("souvenirs","Drag to move"),
             "sDragToResize": t("souvenirs","Drag to resize"),
+            "sResetPanZoom": t("souvenirs","Reset zoom and position"),
             "resizeCorners": ['nw', 'ne', 'sw', 'se'],
             // State of the corner drag in progress (pointer id, start position,
             // page size in px, original geometry), null when not resizing.
@@ -133,6 +161,7 @@ export default {
         EditableText,
         Delete,
         CursorMove,
+        FitToScreen,
     },
     watch: {
         "geometryKey": function() {
@@ -140,14 +169,23 @@ export default {
             // which resizes this element's box. A zoom/offset cover-fit is computed
             // from the box size at load time, so recompute it on resize, otherwise
             // the image would keep a stale transform and letterbox in its new cell.
-            if (this.loadingImage != null && this.loadingImage.complete
-                && (this.sClass == 'ImageElement' || this.sClass == 'VideoElement')
-                && this.sTransformType == IMG_ZOOMOFFSET) {
-                this.$nextTick(() => {
-                    this.imageStyle = getImageZoomOffsetStyle(this.sZoom, this.sOffsetX, this.sOffsetY,
-                        this.$refs.eldiv.clientWidth, this.$refs.eldiv.clientHeight,
-                        this.loadingImage.width, this.loadingImage.height);
-                });
+            this.$nextTick(() => {
+                this.refreshImageStyle();
+            });
+        },
+        "panZoomKey": function() {
+            // The committed pan/zoom props caught up with (or replaced) the
+            // preview: hand the rendering back to them. Not while a pointer
+            // gesture is running — it keeps driving the preview.
+            if (this.panZoomGesture == null) {
+                this.panZoomPreview = null;
+            }
+            this.refreshImageStyle();
+        },
+        "editMode": function(newEdit) {
+            // Leaving edit mode commits a still-pending wheel zoom.
+            if (!newEdit) {
+                this.commitPanZoom();
             }
         },
         "preload": function(newPreload, oldPreload) {
@@ -184,12 +222,20 @@ export default {
     },
     created: function() {
             // Plain properties, not data(): wrapping the Photo Sphere Viewer
-            // plugin in a reactive proxy is useless and fragile.
+            // plugin in a reactive proxy is useless and fragile. Same for the
+            // pan & zoom gesture bookkeeping (pointer positions at 60+ Hz) —
+            // the reactive rendering is driven by panZoomPreview alone.
             this.autorotate = null;
             this.panoReady = false;
+            this.panZoomGesture = null;
+            this.wheelCommitTimer = null;
             if (this.preload) {
                 this.loadImage();
             }
+        },
+    beforeUnmount: function() {
+            // Commit a still-pending wheel zoom instead of dropping it.
+            this.commitPanZoom();
         },
     computed: {
         'sWidth': function() {
@@ -207,13 +253,33 @@ export default {
             return Math.floor(eh*(this.sBottom-this.sTop)/100);
         },
         'isImgCenterCrop': function() {
-            return (this.sTransformType == IMG_CENTERCROP);
+            // A pan/zoom preview always renders as zoom-offset, whatever the
+            // committed transform type still says.
+            return (this.panZoomPreview == null && this.sTransformType == IMG_CENTERCROP);
         },
         'isImgFill': function() {
-            return (this.sTransformType == IMG_FILL);
+            return (this.panZoomPreview == null && this.sTransformType == IMG_FILL);
+        },
+        'effectiveZoom': function() {
+            return this.panZoomPreview != null ? this.panZoomPreview.zoom : this.sZoom;
+        },
+        'canPanZoom': function() {
+            // Pan & zoom applies to image elements in edit mode (issue #27),
+            // once the image is loaded (the math needs its natural size) — and
+            // only on the currently displayed page: on a peeking neighbor page
+            // a touch drag must keep scrolling the album, not pan the image.
+            return this.editMode && this.isFocus
+                && this.sClass != null && this.sClass.endsWith('ImageElement')
+                && this.imgSize != null && this.imgSize.width > 0 && this.imgSize.height > 0;
         },
         'geometryKey': function() {
             return [this.sTop, this.sBottom, this.sLeft, this.sRight].join(',');
+        },
+        'panZoomKey': function() {
+            return [this.sZoom, this.sOffsetX, this.sOffsetY, this.sTransformType].join(',');
+        },
+        'isTextElement': function() {
+            return this.sClass != null && this.sClass.endsWith('TextElement');
         },
         'isRemovable': function() {
             // Media tiles (image / video / paint) and text elements can be removed.
@@ -276,9 +342,8 @@ export default {
         },
         onLoadedImage: function() {
             this.sImageSrc = this.loadingImage.src;
-            if (((this.sClass == 'ImageElement') || (this.sClass == 'VideoElement')) && (this.sTransformType == IMG_ZOOMOFFSET)) {
-                this.imageStyle = getImageZoomOffsetStyle(this.sZoom,this.sOffsetX,this.sOffsetY,this.$refs.eldiv.clientWidth,this.$refs.eldiv.clientHeight,this.loadingImage.width,this.loadingImage.height);
-            }
+            this.imgSize = { width: this.loadingImage.width, height: this.loadingImage.height };
+            this.refreshImageStyle();
             if (this.isPhotosphere()) {
                 var pano = new Viewer({
                     panorama: this.imageUrl(true),
@@ -325,6 +390,11 @@ export default {
             return (this.sMime == GOOGLE_PANORAMA_360_MIMETYPE);
         },
         openImgFull: function() {
+            // In edit mode a click on the image is the tail of a pan gesture
+            // (or a stray press), not a request for the fullscreen viewer.
+            if (this.editMode) {
+                return;
+            }
             this.$emit("imagefull",this.imageUrl(true),this.isPhotosphere());
         },
         openVideo: function() {
@@ -340,23 +410,206 @@ export default {
             // Bubble the removal up with this element's id (sId).
             this.$emit("remove-element", this.sId);
         },
-        onRootMouseDown: function(event) {
-            // Decide per-press whether the tile is draggable: a press inside the
-            // caption editor must edit text, not start a drag. The browser makes
-            // the selection-vs-drag call during this very mousedown's default
-            // action, before Vue's async attribute patch would land, so the
-            // attribute is also updated synchronously here.
-            this.dragSuppressed = !!(event.target && event.target.isContentEditable);
-            if (this.$refs.eldiv) {
-                this.$refs.eldiv.setAttribute("draggable", String(this.isDraggable && !this.dragSuppressed));
+        refreshImageStyle: function() {
+            // Recompute the inline zoom-offset transform of the image from the
+            // effective values: the gesture preview when one is active, the
+            // committed props otherwise. For the other transform types the
+            // rendering is purely CSS classes (fill/centercrop): no inline style.
+            if (this.imgSize == null || this.$refs.eldiv == null
+                || !(this.sClass == 'ImageElement' || this.sClass == 'VideoElement')) {
+                return;
             }
+            var box = this.$refs.eldiv.getBoundingClientRect();
+            if (box.width <= 0 || box.height <= 0) {
+                return;
+            }
+            if (this.panZoomPreview != null) {
+                this.imageStyle = getImageZoomOffsetStyle(this.panZoomPreview.zoom,
+                    this.panZoomPreview.offsetX, this.panZoomPreview.offsetY,
+                    box.width, box.height, this.imgSize.width, this.imgSize.height);
+            } else if (this.sTransformType == IMG_ZOOMOFFSET) {
+                this.imageStyle = getImageZoomOffsetStyle(this.sZoom, this.sOffsetX, this.sOffsetY,
+                    box.width, box.height, this.imgSize.width, this.imgSize.height);
+            } else {
+                this.imageStyle = {};
+            }
+        },
+        basePanZoomState: function(box) {
+            // The state a new gesture step starts from: the still-displayed
+            // preview if there is one (e.g. a pending wheel commit), otherwise
+            // the committed props converted to zoom-offset values.
+            if (this.panZoomPreview != null) {
+                return this.panZoomPreview;
+            }
+            return initialPanZoom({ transformType: this.sTransformType, zoom: this.sZoom,
+                offsetX: this.sOffsetX, offsetY: this.sOffsetY }, box, this.imgSize);
+        },
+        rebasePanZoomGesture: function() {
+            // (Re)anchor the gesture on the current pointer set: called when a
+            // pointer goes down or up, so pan (1 pointer) and pinch (2 pointers)
+            // phases compose without jumps.
+            var g = this.panZoomGesture;
+            var points = Array.from(g.pointers.values());
+            g.box = this.$refs.eldiv.getBoundingClientRect();
+            g.state = this.basePanZoomState(g.box);
+            g.startMid = {
+                x: points.length >= 2 ? (points[0].x + points[1].x) / 2 : points[0].x,
+                y: points.length >= 2 ? (points[0].y + points[1].y) / 2 : points[0].y,
+            };
+            g.startDist = points.length >= 2
+                ? Math.hypot(points[1].x - points[0].x, points[1].y - points[0].y) : 0;
+        },
+        onImagePointerDown: function(event) {
+            if (!this.canPanZoom || this.resizing != null) {
+                return;
+            }
+            // The press belongs to the pan/pinch: keep the browser from starting
+            // a native image drag or a text selection with it.
+            event.preventDefault();
+            // A pending wheel commit merges into this gesture (committed at its end).
+            if (this.wheelCommitTimer != null) {
+                clearTimeout(this.wheelCommitTimer);
+                this.wheelCommitTimer = null;
+            }
+            // Route the whole gesture to the image, even when the pointer
+            // leaves it while dragging.
+            if (event.currentTarget.setPointerCapture) {
+                event.currentTarget.setPointerCapture(event.pointerId);
+            }
+            if (this.panZoomGesture == null) {
+                this.panZoomGesture = { pointers: new Map() };
+            }
+            this.panZoomGesture.pointers.set(event.pointerId, { x: event.clientX, y: event.clientY });
+            this.rebasePanZoomGesture();
+        },
+        onImagePointerMove: function(event) {
+            var g = this.panZoomGesture;
+            if (g == null || !g.pointers.has(event.pointerId)) {
+                return;
+            }
+            g.pointers.set(event.pointerId, { x: event.clientX, y: event.clientY });
+            var points = Array.from(g.pointers.values());
+            var state;
+            if (points.length >= 2) {
+                // Pinch: zoom by the distance ratio about the start midpoint,
+                // then pan by the midpoint travel.
+                var mid = { x: (points[0].x + points[1].x) / 2, y: (points[0].y + points[1].y) / 2 };
+                var dist = Math.hypot(points[1].x - points[0].x, points[1].y - points[0].y);
+                var factor = g.startDist > 0 ? dist / g.startDist : 1;
+                state = zoomAt(g.state, factor,
+                    { x: g.startMid.x - g.box.left, y: g.startMid.y - g.box.top }, g.box, this.imgSize);
+                state = panBy(state, { x: mid.x - g.startMid.x, y: mid.y - g.startMid.y }, g.box, this.imgSize);
+            } else {
+                state = panBy(g.state,
+                    { x: points[0].x - g.startMid.x, y: points[0].y - g.startMid.y }, g.box, this.imgSize);
+            }
+            this.panZoomPreview = state;
+            this.refreshImageStyle();
+        },
+        onImagePointerUp: function(event) {
+            var g = this.panZoomGesture;
+            if (g == null || !g.pointers.has(event.pointerId)) {
+                return;
+            }
+            g.pointers.delete(event.pointerId);
+            if (g.pointers.size > 0) {
+                // Pinch dropping to a single finger: continue as a pan.
+                this.rebasePanZoomGesture();
+                return;
+            }
+            this.panZoomGesture = null;
+            this.commitPanZoom();
+        },
+        onImagePointerCancel: function(event) {
+            var g = this.panZoomGesture;
+            if (g == null || !g.pointers.has(event.pointerId)) {
+                return;
+            }
+            g.pointers.delete(event.pointerId);
+            if (g.pointers.size > 0) {
+                this.rebasePanZoomGesture();
+                return;
+            }
+            // A cancelled gesture snaps back to the committed values.
+            this.panZoomGesture = null;
+            this.panZoomPreview = null;
+            this.refreshImageStyle();
+        },
+        onImageWheel: function(event) {
+            // Zoom about the cursor; a pointer gesture in progress owns the
+            // preview, so wheel input is ignored during one.
+            if (!this.canPanZoom || this.panZoomGesture != null) {
+                return;
+            }
+            event.preventDefault();
+            var box = this.$refs.eldiv.getBoundingClientRect();
+            if (box.width <= 0 || box.height <= 0) {
+                return;
+            }
+            // deltaMode 1 means lines, not pixels (e.g. Firefox with a plain mouse).
+            var delta = event.deltaMode === 1 ? event.deltaY * 40 : event.deltaY;
+            this.panZoomPreview = zoomAt(this.basePanZoomState(box), Math.exp(-delta * WHEEL_ZOOM_SPEED),
+                { x: event.clientX - box.left, y: event.clientY - box.top }, box, this.imgSize);
+            this.refreshImageStyle();
+            if (this.wheelCommitTimer != null) {
+                clearTimeout(this.wheelCommitTimer);
+            }
+            this.wheelCommitTimer = setTimeout(() => { this.commitPanZoom(); }, WHEEL_COMMIT_DELAY_MS);
+        },
+        commitPanZoom: function() {
+            if (this.wheelCommitTimer != null) {
+                clearTimeout(this.wheelCommitTimer);
+                this.wheelCommitTimer = null;
+            }
+            if (this.panZoomPreview == null) {
+                return;
+            }
+            var rounded = roundPanZoom(this.panZoomPreview);
+            if (rounded.zoom === this.sZoom && rounded.offsetX === this.sOffsetX
+                && rounded.offsetY === this.sOffsetY && this.sTransformType === IMG_ZOOMOFFSET) {
+                this.panZoomPreview = null;
+                this.refreshImageStyle();
+                return;
+            }
+            // Keep showing the (rounded) preview until the committed props flow
+            // back down (the panZoomKey watcher then clears it). Bubble the new
+            // values up with this element's id (sId) so the album can patch and
+            // persist them; the transform type becomes zoom-offset, which is
+            // what the first gesture on a fill/center-crop element switches to.
+            this.panZoomPreview = rounded;
+            this.refreshImageStyle();
+            this.$emit("pan-zoom-element", this.sId,
+                { zoom: rounded.zoom, offsetX: rounded.offsetX, offsetY: rounded.offsetY, transformType: IMG_ZOOMOFFSET });
+        },
+        onPanZoomReset: function() {
+            // Back to the default framing: drop any gesture in progress and any
+            // pending wheel commit, then persist plain cover-fit — unless the
+            // committed element already renders that way (zoom-offset at
+            // 100/0/0, or center-crop, which is the same rendering).
+            if (this.wheelCommitTimer != null) {
+                clearTimeout(this.wheelCommitTimer);
+                this.wheelCommitTimer = null;
+            }
+            this.panZoomGesture = null;
+            var isDefault = (this.sTransformType === IMG_ZOOMOFFSET && this.sZoom === 100
+                    && this.sOffsetX === 0 && this.sOffsetY === 0)
+                || this.sTransformType === IMG_CENTERCROP;
+            if (isDefault) {
+                this.panZoomPreview = null;
+                this.refreshImageStyle();
+                return;
+            }
+            this.panZoomPreview = { zoom: 100, offsetX: 0, offsetY: 0 };
+            this.refreshImageStyle();
+            this.$emit("pan-zoom-element", this.sId,
+                { zoom: 100, offsetX: 0, offsetY: 0, transformType: IMG_ZOOMOFFSET });
         },
         onResizeStart: function(event, corner) {
             if (!this.isResizable || this.resizing != null) {
                 return;
             }
-            // The press belongs to the resize: keep it from starting an HTML5
-            // drag of the tile and from reaching onRootMouseDown.
+            // The press belongs to the resize: keep it from selecting text or
+            // reaching the pan & zoom handlers below.
             event.preventDefault();
             event.stopPropagation();
             var page = this.$refs.eldiv ? this.$refs.eldiv.parentElement : null;
@@ -413,17 +666,19 @@ export default {
             this.resizePreview = null;
         },
         onDragStart: function(event) {
-            if (!this.isDraggable || this.dragSuppressed || this.resizing != null) {
+            // Drags start from the handle button only (issue #27); the tile
+            // surface is reserved for the pan & zoom gestures.
+            if (!this.isDraggable || this.resizing != null) {
                 event.preventDefault();
                 return;
             }
-            // A drag starting inside the caption editor is the browser dragging
-            // selected text: leave it to the native behavior (our drop targets
-            // ignore it, as it does not carry the element payload).
-            if (event.target && event.target.isContentEditable) {
-                return;
-            }
             setElementDragData(event, this.sPageId, this.sId);
+            // Show the whole tile in flight, not just the handle button.
+            if (event.dataTransfer.setDragImage && this.$refs.eldiv) {
+                var rect = this.$refs.eldiv.getBoundingClientRect();
+                event.dataTransfer.setDragImage(this.$refs.eldiv,
+                    event.clientX - rect.left, event.clientY - rect.top);
+            }
             this.isDragging = true;
         },
         onDragEnd: function() {
@@ -560,11 +815,12 @@ function basename(path) {
     overflow: hidden;
 }
 
-/* Draggable tiles (edit mode) must receive pointer/drag events; the base
-   .s-element disables them (children normally opt back in). */
+/* Editable tiles (edit mode) must receive pointer/drag events — as drop
+   targets and for the pan & zoom gestures; the base .s-element disables them
+   (children normally opt back in). No grab cursor here: moving the tile is
+   done from the handle button only. */
 .s-element--draggable {
 	pointer-events: all;
-	cursor: grab;
 }
 
 /* The tile being dragged: ghost it so the user sees it is in flight. */
@@ -572,9 +828,10 @@ function basename(path) {
 	opacity: 0.4;
 }
 
-/* Grab handle, mirroring the delete button in the opposite corner. It floats
-   above the caption editor (which fills the whole cell on text tiles), so text
-   elements stay draggable even though a press inside the editor never drags.
+/* Grab handle, mirroring the delete button in the opposite corner: the only
+   drag source for moving the element to another page/slot (the tile surface
+   itself pans the image). It floats above the caption editor, so text elements
+   stay draggable even though a press inside the editor never drags.
    It is a primary NcButton so its face (color, hover) is exactly the one of the
    other edit buttons ("Add image", ...); only placement is set here. */
 .s-element-drag-handle {
@@ -588,6 +845,16 @@ function basename(path) {
 .s-element-drag-handle,
 .s-element-drag-handle :deep(*) {
 	cursor: grab;
+}
+
+/* Reset-framing button, just under the move handle (whose height follows the
+   theme's clickable-area size, e.g. 34px in compact mode). */
+.s-element-pan-reset {
+	position: absolute;
+	top: calc(6px + var(--default-clickable-area, 44px) + 6px);
+	left: 6px;
+	z-index: 8;
+	pointer-events: all;
 }
 
 /* Corner resize handles (edit mode). Above the drag/delete buttons (z 8) so
@@ -671,6 +938,11 @@ function basename(path) {
 	justify-content: center;
 	text-align: center;
     white-space: pre-wrap;
+	/* The text layer covers the whole cell above the image: keep it
+	   click-through so it cannot swallow the pan & zoom gestures (in edit mode
+	   the tile root re-enables pointer events, which children inherit). When it
+	   is actually editable, EditableText's own --editing rule opts back in. */
+	pointer-events: none;
 }
 
 center {
@@ -696,6 +968,13 @@ center {
 
 .image-element {
     pointer-events: all;
+}
+
+/* Image surface while it can be panned/zoomed (edit mode). touch-action:none
+   keeps the browser from turning the pan/pinch into a scroll on touch screens. */
+.image-element--pan {
+    cursor: move;
+    touch-action: none;
 }
 
 .video-element {

--- a/src/utils/__tests__/albumEdit.test.js
+++ b/src/utils/__tests__/albumEdit.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { setElementText, setElementGeometry, relayoutElements, removeElement, buildImageElement, buildTextElement, buildPage, addElement, swapElements } from '../albumEdit.js'
+import { setElementText, setElementGeometry, setElementPanZoom, relayoutElements, removeElement, buildImageElement, buildTextElement, buildPage, addElement, swapElements } from '../albumEdit.js'
 
 describe('setElementText', () => {
     const makePage = () => ({
@@ -379,5 +379,70 @@ describe('setElementGeometry', () => {
 
     it('tolerates a page without an elements array', () => {
         expect(setElementGeometry({ id: 'p' }, 'el-1', { top: 0, left: 0, right: 100, bottom: 100 }).elements).toEqual([])
+    })
+})
+
+describe('setElementPanZoom', () => {
+    const makePage = () => ({
+        id: 'page-1',
+        customPageField: 'keep-me',
+        elements: [
+            {
+                id: 'el-1',
+                class: 'ImageElement',
+                image: 'data/a.jpg',
+                text: 'caption',
+                top: 0,
+                left: 0,
+                right: 100,
+                bottom: 50,
+                zoom: 100,
+                offsetX: 0,
+                offsetY: 0,
+                transformType: 1,
+                // Unknown per-element field that must be preserved.
+                androidOnlyField: 42,
+            },
+            {
+                id: 'el-2',
+                class: 'ImageElement',
+                image: 'data/b.jpg',
+                zoom: 100,
+                offsetX: 0,
+                offsetY: 0,
+                transformType: 2,
+            },
+        ],
+    })
+
+    it('replaces only the targeted element pan/zoom and transform type', () => {
+        const result = setElementPanZoom(makePage(), 'el-1', { zoom: 150, offsetX: 10, offsetY: -5, transformType: 2 })
+        expect(result.elements[0]).toMatchObject({ zoom: 150, offsetX: 10, offsetY: -5, transformType: 2 })
+        expect(result.elements[1]).toMatchObject({ zoom: 100, offsetX: 0, offsetY: 0, transformType: 2 })
+    })
+
+    it('preserves all other element and page fields, including unknown ones', () => {
+        const result = setElementPanZoom(makePage(), 'el-1', { zoom: 150, offsetX: 10, offsetY: -5, transformType: 2 })
+        expect(result.elements[0]).toMatchObject({
+            image: 'data/a.jpg', text: 'caption',
+            top: 0, left: 0, right: 100, bottom: 50,
+            androidOnlyField: 42,
+        })
+        expect(result.customPageField).toBe('keep-me')
+    })
+
+    it('does not mutate the original page or its elements', () => {
+        const page = makePage()
+        setElementPanZoom(page, 'el-1', { zoom: 150, offsetX: 10, offsetY: -5, transformType: 2 })
+        expect(page.elements[0]).toMatchObject({ zoom: 100, offsetX: 0, offsetY: 0, transformType: 1 })
+    })
+
+    it('is a no-op when the element id is not found', () => {
+        const result = setElementPanZoom(makePage(), 'missing', { zoom: 150, offsetX: 10, offsetY: -5, transformType: 2 })
+        expect(result.elements[0]).toMatchObject({ zoom: 100, offsetX: 0, offsetY: 0, transformType: 1 })
+    })
+
+    it('tolerates a page without an elements array', () => {
+        expect(setElementPanZoom({ id: 'p' }, 'el-1', { zoom: 100, offsetX: 0, offsetY: 0, transformType: 2 }).elements).toEqual([])
     })
 })

--- a/src/utils/__tests__/imagePanZoom.test.js
+++ b/src/utils/__tests__/imagePanZoom.test.js
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest'
+import { initialPanZoom, panBy, zoomAt, roundPanZoom, ZOOM_MIN, ZOOM_MAX } from '../imagePanZoom.js'
+
+// A square image in a square box: cover-fit fills the box exactly, which makes
+// the expected values easy to derive by hand.
+const BOX = { width: 1000, height: 1000 }
+const IMG = { width: 2000, height: 2000 }
+
+describe('initialPanZoom', () => {
+    it('keeps the stored values of a zoom-offset element', () => {
+        expect(initialPanZoom({ transformType: 2, zoom: 150, offsetX: 5, offsetY: -3 }, BOX, IMG))
+            .toEqual({ zoom: 150, offsetX: 5, offsetY: -3 })
+    })
+
+    it('falls back to plain cover-fit on missing zoom-offset values', () => {
+        expect(initialPanZoom({ transformType: 2, zoom: undefined, offsetX: undefined, offsetY: undefined }, BOX, IMG))
+            .toEqual({ zoom: 100, offsetX: 0, offsetY: 0 })
+    })
+
+    it('maps center-crop to cover-fit (zoom 100, no offset)', () => {
+        expect(initialPanZoom({ transformType: 1, zoom: 0, offsetX: 0, offsetY: 0 }, BOX, IMG))
+            .toEqual({ zoom: 100, offsetX: 0, offsetY: 0 })
+    })
+
+    it('maps fill (contain) to the visually equivalent zoom', () => {
+        // 2000x1000 image in a 1000x1000 box: contain scale 0.5, cover scale 1.
+        expect(initialPanZoom({ transformType: 0, zoom: 0, offsetX: 0, offsetY: 0 }, BOX, { width: 2000, height: 1000 }))
+            .toEqual({ zoom: 50, offsetX: 0, offsetY: 0 })
+    })
+})
+
+describe('panBy', () => {
+    it('converts a pointer delta to offset percents at zoom 100', () => {
+        const state = panBy({ zoom: 100, offsetX: 0, offsetY: 0 }, { x: 100, y: -50 }, BOX, IMG)
+        expect(state).toEqual({ zoom: 100, offsetX: 10, offsetY: -5 })
+    })
+
+    it('divides the delta by the zoom so the image follows the pointer 1:1', () => {
+        const state = panBy({ zoom: 200, offsetX: 0, offsetY: 0 }, { x: 100, y: 100 }, BOX, IMG)
+        expect(state).toEqual({ zoom: 200, offsetX: 5, offsetY: 5 })
+    })
+
+    it('clamps so the image cannot leave the box entirely', () => {
+        // Square cover-fit at zoom 100: the image may shift at most one full box.
+        const state = panBy({ zoom: 100, offsetX: 0, offsetY: 0 }, { x: 100000, y: -100000 }, BOX, IMG)
+        expect(state).toEqual({ zoom: 100, offsetX: 100, offsetY: -100 })
+    })
+
+    it('allows a wider pan range for an image that overflows the box', () => {
+        // 2000x1000 image cover-fitted in a 1000x1000 box overflows horizontally
+        // by 500px on each side: the clamp accounts for that extra travel.
+        const state = panBy({ zoom: 100, offsetX: 0, offsetY: 0 }, { x: 100000, y: 0 }, BOX, { width: 2000, height: 1000 })
+        expect(state.offsetX).toBe(150)
+    })
+})
+
+describe('zoomAt', () => {
+    it('scales the zoom and keeps the anchor point fixed', () => {
+        // Doubling the zoom about the box center: offsets compensate by
+        // anchor * (1/2 - 1) = -250px = -25% of the box.
+        const state = zoomAt({ zoom: 100, offsetX: 0, offsetY: 0 }, 2, { x: 500, y: 500 }, BOX, IMG)
+        expect(state).toEqual({ zoom: 200, offsetX: -25, offsetY: -25 })
+    })
+
+    it('leaves the state unchanged for a top-left anchor', () => {
+        // The rendered layout scales about the box origin, so that point is
+        // naturally fixed: no offset compensation needed.
+        const state = zoomAt({ zoom: 100, offsetX: 4, offsetY: 2 }, 2, { x: 0, y: 0 }, BOX, IMG)
+        expect(state).toEqual({ zoom: 200, offsetX: 4, offsetY: 2 })
+    })
+
+    it('is reversible: zooming in then out restores the state', () => {
+        const start = { zoom: 100, offsetX: 10, offsetY: -10 }
+        const zoomed = zoomAt(start, 2, { x: 300, y: 700 }, BOX, IMG)
+        const back = zoomAt(zoomed, 0.5, { x: 300, y: 700 }, BOX, IMG)
+        expect(back.zoom).toBeCloseTo(start.zoom, 6)
+        expect(back.offsetX).toBeCloseTo(start.offsetX, 6)
+        expect(back.offsetY).toBeCloseTo(start.offsetY, 6)
+    })
+
+    it('clamps the zoom to the allowed range', () => {
+        expect(zoomAt({ zoom: 100, offsetX: 0, offsetY: 0 }, 1000, { x: 0, y: 0 }, BOX, IMG).zoom).toBe(ZOOM_MAX)
+        expect(zoomAt({ zoom: 100, offsetX: 0, offsetY: 0 }, 0.001, { x: 0, y: 0 }, BOX, IMG).zoom).toBe(ZOOM_MIN)
+    })
+})
+
+describe('roundPanZoom', () => {
+    it('rounds all values to 2 decimals', () => {
+        expect(roundPanZoom({ zoom: 122.140275, offsetX: -9.06346, offsetY: 0.005 }))
+            .toEqual({ zoom: 122.14, offsetX: -9.06, offsetY: 0.01 })
+    })
+})

--- a/src/utils/albumEdit.js
+++ b/src/utils/albumEdit.js
@@ -178,6 +178,31 @@ export function setElementGeometry(page, elementId, { top, left, right, bottom }
 
 /**
  * Return a copy of `page` in which the element identified by `elementId` has its
+ * pan & zoom values (zoom, offsetX, offsetY — album.json percent units) and its
+ * `transformType` replaced. The transform type is included because the first
+ * pan/zoom gesture on a fill/center-crop element switches it to the zoom-offset
+ * type (issue #27). All other fields of the page and of every element (including
+ * ones this app does not know about) are preserved untouched.
+ *
+ * @param {object} page - a page object, expected to contain an `elements` array
+ * @param {string} elementId - the `id` of the element being panned/zoomed
+ * @param {{zoom: number, offsetX: number, offsetY: number, transformType: number}} panZoom
+ * @returns {object} a new page object with the single change applied
+ */
+export function setElementPanZoom(page, elementId, { zoom, offsetX, offsetY, transformType }) {
+    const elements = Array.isArray(page.elements) ? page.elements : []
+    return {
+        ...page,
+        elements: elements.map(element =>
+            element.id === elementId
+                ? { ...element, zoom, offsetX, offsetY, transformType }
+                : element,
+        ),
+    }
+}
+
+/**
+ * Return a copy of `page` in which the element identified by `elementId` has its
  * `text` set to `newText`. All other fields of the page and of every element
  * (including ones this app does not know about) are preserved untouched.
  *

--- a/src/utils/imagePanZoom.js
+++ b/src/utils/imagePanZoom.js
@@ -1,0 +1,149 @@
+/**
+ * Pure, framework-free math for the in-place pan & zoom of image elements
+ * (issue #27), matching the rendering done by getImageZoomOffsetStyle in
+ * selement.vue (itself matching the Android app's zoom/offset transform):
+ *
+ *   rendered position of image point q (px, element-box coordinates):
+ *     P(q) = z * ((boxSize - coverSize) / 2 + offsetPx + q)
+ *
+ * where z = zoom / 100, coverSize is the image size cover-fitted to the box at
+ * zoom 100, and offsetPx = offset% * boxSize / 100. In other words the layout
+ * is the centered cover-fit shifted by the offsets, scaled by the zoom about
+ * the box's top-left corner. The helpers below invert that mapping so pointer
+ * deltas (px) become offset/zoom deltas (album.json percent units).
+ *
+ * All functions take:
+ *   state - { zoom, offsetX, offsetY } in album.json units (percents)
+ *   box   - { width, height } of the element box, in px
+ *   img   - { width, height } natural size of the image, in px
+ * and never mutate their arguments.
+ */
+
+// The zoom the user can set by gesture, in album.json percent units
+// (100 = cover-fit). Below 100 the tile shows the blurred backdrop.
+export const ZOOM_MIN = 10
+export const ZOOM_MAX = 1000
+
+const IMG_FILL = 0
+const IMG_ZOOMOFFSET = 2
+
+/**
+ * Displayed size of the image at zoom 100: cover-fitted to the box (scaled by
+ * max(widthScale, heightScale), so one dimension equals the box and the other
+ * overflows).
+ */
+function coverSize(box, img) {
+    const scale = Math.max(box.width / img.width, box.height / img.height)
+    return { width: img.width * scale, height: img.height * scale }
+}
+
+function clamp(value, min, max) {
+    return Math.min(Math.max(value, min), max)
+}
+
+/**
+ * Clamp a state to the allowed zoom range and to offsets that keep the image
+ * at least touching the box (so it can never be panned fully out of view).
+ * Bounds, from P(q) above: the image's leading edge must not pass the box's
+ * trailing edge (offsetPx <= boxSize/z - (boxSize-cover)/2) and its trailing
+ * edge must not pass the box's leading edge (offsetPx >= -(boxSize+cover)/2).
+ */
+function clampState(state, box, img) {
+    const zoom = clamp(state.zoom, ZOOM_MIN, ZOOM_MAX)
+    const z = zoom / 100
+    const cover = coverSize(box, img)
+    const minX = -(box.width + cover.width) / 2 * 100 / box.width
+    const maxX = (box.width / z - (box.width - cover.width) / 2) * 100 / box.width
+    const minY = -(box.height + cover.height) / 2 * 100 / box.height
+    const maxY = (box.height / z - (box.height - cover.height) / 2) * 100 / box.height
+    return {
+        zoom: zoom,
+        offsetX: clamp(state.offsetX, minX, maxX),
+        offsetY: clamp(state.offsetY, minY, maxY),
+    }
+}
+
+/**
+ * The pan/zoom state a gesture starts from, for any of the three transform
+ * types. Zoom-offset elements keep their stored values; center-crop is exactly
+ * zoom-offset at (100, 0, 0); fill (contain) converts to the equivalent
+ * zoom-offset zoom (100 * containScale / coverScale), so switching the element
+ * to zoom-offset on the first gesture does not visually jump.
+ *
+ * @param {{transformType: number, zoom: number, offsetX: number, offsetY: number}} element
+ * @param {{width: number, height: number}} box
+ * @param {{width: number, height: number}} img
+ * @returns {{zoom: number, offsetX: number, offsetY: number}}
+ */
+export function initialPanZoom(element, box, img) {
+    if (element.transformType === IMG_ZOOMOFFSET) {
+        return clampState({
+            zoom: Number.isFinite(element.zoom) && element.zoom > 0 ? element.zoom : 100,
+            offsetX: Number.isFinite(element.offsetX) ? element.offsetX : 0,
+            offsetY: Number.isFinite(element.offsetY) ? element.offsetY : 0,
+        }, box, img)
+    }
+    if (element.transformType === IMG_FILL) {
+        const contain = Math.min(box.width / img.width, box.height / img.height)
+        const cover = Math.max(box.width / img.width, box.height / img.height)
+        return clampState({ zoom: 100 * contain / cover, offsetX: 0, offsetY: 0 }, box, img)
+    }
+    // IMG_CENTERCROP (and anything unknown): plain cover-fit.
+    return { zoom: 100, offsetX: 0, offsetY: 0 }
+}
+
+/**
+ * Pan the image so it follows a pointer that moved by `delta` px: the rendered
+ * layout is scaled by z about the box origin, so a 1px pointer move is a 1/z px
+ * offset move.
+ *
+ * @param {{zoom: number, offsetX: number, offsetY: number}} state
+ * @param {{x: number, y: number}} delta - pointer movement in px
+ * @param {{width: number, height: number}} box
+ * @param {{width: number, height: number}} img
+ * @returns {{zoom: number, offsetX: number, offsetY: number}} the panned state
+ */
+export function panBy(state, delta, box, img) {
+    const z = state.zoom / 100
+    return clampState({
+        zoom: state.zoom,
+        offsetX: state.offsetX + delta.x * 100 / (z * box.width),
+        offsetY: state.offsetY + delta.y * 100 / (z * box.height),
+    }, box, img)
+}
+
+/**
+ * Multiply the zoom by `factor`, keeping the image point currently under
+ * `anchor` (px, box coordinates — e.g. the mouse cursor or the pinch midpoint)
+ * fixed on screen: solving P(q) = anchor for both zooms gives
+ * offsetPx' = offsetPx + anchor * (1/z' - 1/z).
+ *
+ * @param {{zoom: number, offsetX: number, offsetY: number}} state
+ * @param {number} factor - multiplicative zoom change (>1 zooms in)
+ * @param {{x: number, y: number}} anchor - fixed point, in px from the box's top-left
+ * @param {{width: number, height: number}} box
+ * @param {{width: number, height: number}} img
+ * @returns {{zoom: number, offsetX: number, offsetY: number}} the zoomed state
+ */
+export function zoomAt(state, factor, anchor, box, img) {
+    const z0 = state.zoom / 100
+    const zoom = clamp(state.zoom * factor, ZOOM_MIN, ZOOM_MAX)
+    const z1 = zoom / 100
+    return clampState({
+        zoom: zoom,
+        offsetX: state.offsetX + anchor.x * (1 / z1 - 1 / z0) * 100 / box.width,
+        offsetY: state.offsetY + anchor.y * (1 / z1 - 1 / z0) * 100 / box.height,
+    }, box, img)
+}
+
+/**
+ * Round a state to 2 decimals for persistence, like the geometry values
+ * (album.json stores plain numbers; sub-percent precision is plenty).
+ *
+ * @param {{zoom: number, offsetX: number, offsetY: number}} state
+ * @returns {{zoom: number, offsetX: number, offsetY: number}}
+ */
+export function roundPanZoom(state) {
+    const round2 = value => Math.round(value * 100) / 100
+    return { zoom: round2(state.zoom), offsetX: round2(state.offsetX), offsetY: round2(state.offsetY) }
+}


### PR DESCRIPTION
Implements #27.

## What this does

- **Pan**: in edit mode, dragging inside an image element moves the image within its box (live preview, committed on release).
- **Zoom**: mouse wheel zooms about the cursor (successive notches merge into a single save after a short pause); two-finger pinch zooms on touch screens.
- The element's `zoom` / `offsetX` / `offsetY` are set accordingly and persisted through the existing page update endpoint (no backend change needed). Zoom is clamped to 10–1000 % and offsets so the image can never be panned fully out of its box.
- A first gesture on a `fill` / `centercrop` element converts it to `transformType: 2` (zoom-offset) from a visually identical starting state, so nothing jumps.
- A per-image **reset button** just under the move handle restores the default cover-fit framing (no write if the element already renders that way).
- Gestures are active only on the currently displayed page, so a touch drag over a peeking neighbor page keeps scrolling the album.

## Consequences on existing editing UX

- Moving an element to another page/slot now starts **from the handle button only** — the old whole-tile drag is disabled, as the tile surface is reserved for the gestures. The drag still shows the whole tile in flight.
- The inline caption editor now exists **only on text elements**; an image with a stored caption still displays it, read-only and click-through (it previously covered the whole tile and would have swallowed the gestures).
- Clicking an image in edit mode no longer opens the fullscreen viewer (a click is the tail of a pan gesture).

## Implementation notes

- The gesture math lives in a new pure module `src/utils/imagePanZoom.js`, which inverts the existing `getImageZoomOffsetStyle` transform (pointer deltas → offset/zoom percent units), fully unit-tested.
- `setElementPanZoom` in `albumEdit.js` follows the established patch-one-field contract (all unknown album.json fields preserved).
- 34 new frontend tests (gesture emit/preview/cancel, pinch, wheel accumulation, transform-type conversion, clamping, reset button, focus gating, handle-only drag, caption scope); full suite: 131 passing.