### PR TITLE
Mosaic image chooser dialog with direct upload

### DIFF
--- a/src/api/__tests__/davApi.test.js
+++ b/src/api/__tests__/davApi.test.js
@@ -1,0 +1,149 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { listFolder, getPreviewUrl, IMAGE_MIMES } from '../davApi.js'
+
+// A realistic Nextcloud PROPFIND multistatus: the listed collection itself
+// (must be skipped), a subfolder, and two images — one with a space + UTF-8
+// name, percent-encoded in the href as the server does.
+const MULTISTATUS = `<?xml version="1.0"?>
+<d:multistatus xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns" xmlns:oc="http://owncloud.org/ns">
+  <d:response>
+    <d:href>/remote.php/webdav/Photos/Vacances%202024/</d:href>
+    <d:propstat>
+      <d:prop>
+        <d:resourcetype><d:collection/></d:resourcetype>
+        <d:getlastmodified>Mon, 01 Jul 2024 10:00:00 GMT</d:getlastmodified>
+        <oc:fileid>100</oc:fileid>
+      </d:prop>
+      <d:status>HTTP/1.1 200 OK</d:status>
+    </d:propstat>
+    <d:propstat>
+      <d:prop><d:getcontenttype/><d:getcontentlength/></d:prop>
+      <d:status>HTTP/1.1 404 Not Found</d:status>
+    </d:propstat>
+  </d:response>
+  <d:response>
+    <d:href>/remote.php/webdav/Photos/Vacances%202024/Plage/</d:href>
+    <d:propstat>
+      <d:prop>
+        <d:resourcetype><d:collection/></d:resourcetype>
+        <d:getlastmodified>Tue, 02 Jul 2024 08:00:00 GMT</d:getlastmodified>
+        <oc:fileid>101</oc:fileid>
+      </d:prop>
+      <d:status>HTTP/1.1 200 OK</d:status>
+    </d:propstat>
+    <d:propstat>
+      <d:prop><d:getcontenttype/><d:getcontentlength/></d:prop>
+      <d:status>HTTP/1.1 404 Not Found</d:status>
+    </d:propstat>
+  </d:response>
+  <d:response>
+    <d:href>/remote.php/webdav/Photos/Vacances%202024/plage%20%C3%A9t%C3%A9.jpg</d:href>
+    <d:propstat>
+      <d:prop>
+        <d:resourcetype/>
+        <d:getcontenttype>image/jpeg</d:getcontenttype>
+        <d:getcontentlength>123456</d:getcontentlength>
+        <d:getlastmodified>Wed, 03 Jul 2024 12:30:00 GMT</d:getlastmodified>
+        <oc:fileid>202</oc:fileid>
+      </d:prop>
+      <d:status>HTTP/1.1 200 OK</d:status>
+    </d:propstat>
+  </d:response>
+  <d:response>
+    <d:href>/remote.php/webdav/Photos/Vacances%202024/sunset.png</d:href>
+    <d:propstat>
+      <d:prop>
+        <d:resourcetype/>
+        <d:getcontenttype>image/png</d:getcontenttype>
+        <d:getcontentlength>7890</d:getcontentlength>
+        <d:getlastmodified>Mon, 01 Jul 2024 09:00:00 GMT</d:getlastmodified>
+        <oc:fileid>203</oc:fileid>
+      </d:prop>
+      <d:status>HTTP/1.1 200 OK</d:status>
+    </d:propstat>
+  </d:response>
+</d:multistatus>`
+
+describe('davApi', () => {
+    beforeEach(() => {
+        globalThis.OC = { requestToken: 'test-token' }
+        globalThis.fetch = vi.fn(() => Promise.resolve({
+            ok: true,
+            status: 207,
+            text: () => Promise.resolve(MULTISTATUS),
+        }))
+    })
+
+    describe('listFolder', () => {
+        it('issues a Depth-1 PROPFIND on the encoded WebDAV URL with the request token', async () => {
+            await listFolder('Photos/Vacances 2024')
+            const [url, options] = globalThis.fetch.mock.calls[0]
+            expect(url).toMatch(/\/remote\.php\/webdav\/Photos\/Vacances%202024$/)
+            expect(options.method).toBe('PROPFIND')
+            expect(options.headers.Depth).toBe('1')
+            expect(options.headers.requesttoken).toBe('test-token')
+            expect(options.body).toContain('oc:fileid')
+        })
+
+        it('targets the WebDAV root without a trailing slash for the empty path', async () => {
+            await listFolder('')
+            const [url] = globalThis.fetch.mock.calls[0]
+            expect(url).toMatch(/\/remote\.php\/webdav$/)
+        })
+
+        it('parses entries and excludes the listed collection itself', async () => {
+            const entries = await listFolder('Photos/Vacances 2024')
+            expect(entries.map(e => e.basename)).toEqual(['Plage', 'plage été.jpg', 'sunset.png'])
+        })
+
+        it('maps folder entries with isFolder and decoded paths', async () => {
+            const entries = await listFolder('Photos/Vacances 2024')
+            const folder = entries[0]
+            expect(folder).toMatchObject({
+                basename: 'Plage',
+                path: 'Photos/Vacances 2024/Plage',
+                isFolder: true,
+                fileid: '101',
+            })
+        })
+
+        it('maps file entries with mime, size, mtime and fileid', async () => {
+            const entries = await listFolder('Photos/Vacances 2024')
+            const image = entries.find(e => e.basename === 'plage été.jpg')
+            expect(image).toMatchObject({
+                path: 'Photos/Vacances 2024/plage été.jpg',
+                isFolder: false,
+                mime: 'image/jpeg',
+                size: 123456,
+                fileid: '202',
+            })
+            expect(image.mtime).toBe(Date.parse('Wed, 03 Jul 2024 12:30:00 GMT'))
+        })
+
+        it('rejects when the server responds with an error status', async () => {
+            globalThis.fetch = vi.fn(() => Promise.resolve({ ok: false, status: 401 }))
+            await expect(listFolder('Photos')).rejects.toThrow()
+        })
+    })
+
+    describe('getPreviewUrl', () => {
+        it('builds a core preview URL from the fileid', () => {
+            const url = getPreviewUrl('123')
+            expect(url).toContain('/core/preview')
+            expect(url).toContain('fileId=123')
+            expect(url).toContain('x=256&y=256&a=1')
+        })
+
+        it('honours a custom size', () => {
+            expect(getPreviewUrl('123', 512)).toContain('x=512&y=512')
+        })
+    })
+
+    describe('IMAGE_MIMES', () => {
+        it('keeps the mimetypes the old file picker accepted', () => {
+            expect(IMAGE_MIMES).toContain('image/jpeg')
+            expect(IMAGE_MIMES).toContain('image/svg+xml')
+            expect(IMAGE_MIMES).toHaveLength(7)
+        })
+    })
+})

--- a/src/api/davApi.js
+++ b/src/api/davApi.js
@@ -1,0 +1,192 @@
+/**
+ * Minimal WebDAV client for browsing the user's files from the image chooser.
+ *
+ * Deliberately hand-rolled on plain fetch() + OC.requestToken +
+ * generateRemoteUrl('webdav'), like the rest of the API layer (albumApi.js),
+ * rather than @nextcloud/files' getClient(): the latter pulls its auth and
+ * files root from @nextcloud/auth DOM attributes that neither the SPA nor the
+ * test setup provide, and the legacy /remote.php/webdav endpoint needs no uid
+ * in the URL.
+ */
+
+import { generateRemoteUrl, generateUrl } from '@nextcloud/router'
+
+/**
+ * The image mimetypes an album element can display. Shared by the chooser's
+ * grid filter and its upload input's `accept` attribute (formerly the file
+ * picker's mimetype filter in album.vue).
+ */
+export const IMAGE_MIMES = [
+    'image/png',
+    'image/jpeg',
+    'image/gif',
+    'image/webp',
+    'image/bmp',
+    'image/tiff',
+    'image/svg+xml',
+]
+
+/**
+ * Encode a user-files-relative path for use in a WebDAV URL: per-segment
+ * percent-encoding, empty segments dropped so the URL never contains a double
+ * slash (same rules as albumApi.js uploadAsset).
+ * @param {string} path
+ * @returns {string}
+ */
+function encodePath(path) {
+    return path.split('/')
+        .filter(segment => segment !== '')
+        .map(encodeURIComponent)
+        .join('/')
+}
+
+/**
+ * The element's XML name with any namespace prefix stripped, lowercased.
+ * Browsers already strip the prefix from localName when parsing XML;
+ * happy-dom keeps it ("d:response"), so both spellings are normalized here.
+ * @param {Element} el
+ * @returns {string}
+ */
+function davName(el) {
+    return (el.localName || '').toLowerCase().split(':').pop()
+}
+
+/**
+ * Read the text of the first descendant of `parent` with the given DAV local
+ * name, or '' when absent.
+ * @param {Element} parent
+ * @param {string} localName - e.g. "getcontenttype"
+ * @returns {string}
+ */
+function davText(parent, localName) {
+    for (const el of parent.getElementsByTagName('*')) {
+        if (davName(el) === localName) {
+            return el.textContent
+        }
+    }
+    return ''
+}
+
+/**
+ * Whether the propstat element declares the entry a folder
+ * (<d:resourcetype><d:collection/></d:resourcetype>).
+ * @param {Element} parent
+ * @returns {boolean}
+ */
+function davIsCollection(parent) {
+    for (const el of parent.getElementsByTagName('*')) {
+        if (davName(el) === 'collection') {
+            return true
+        }
+    }
+    return false
+}
+
+/**
+ * List a folder of the user's files over WebDAV (PROPFIND Depth: 1).
+ *
+ * Returns the raw entries — no image filtering or sorting, that is the
+ * caller's presentation concern. Each entry is
+ * `{ basename, path, isFolder, mime, size, mtime, fileid }` with `path`
+ * relative to the user's files root and `mtime` in epoch milliseconds.
+ *
+ * @param {string} path - folder path relative to the user's files root, '' = root
+ * @returns {Promise<Array<object>>}
+ */
+export function listFolder(path) {
+    const encodedPath = encodePath(path)
+    const url = generateRemoteUrl('webdav') + (encodedPath ? '/' + encodedPath : '')
+    return fetch(url, {
+        method: 'PROPFIND',
+        headers: {
+            'requesttoken': OC.requestToken,
+            'Depth': '1',
+            'Content-Type': 'application/xml',
+        },
+        body: '<?xml version="1.0"?>\n'
+            + '<d:propfind xmlns:d="DAV:" xmlns:oc="http://owncloud.org/ns">\n'
+            + '  <d:prop>\n'
+            + '    <d:resourcetype/><d:getcontenttype/><d:getcontentlength/>\n'
+            + '    <d:getlastmodified/><oc:fileid/>\n'
+            + '  </d:prop>\n'
+            + '</d:propfind>',
+    }).then(response => {
+        if (!response.ok) {
+            throw new Error('WebDAV PROPFIND failed with status ' + response.status)
+        }
+        return response.text()
+    }).then(xml => parseMultistatus(xml, path))
+}
+
+/**
+ * Parse a WebDAV 207 multistatus document into folder entries.
+ * @param {string} xml - the response body
+ * @param {string} requestedPath - the listed folder, to skip its self entry
+ * @returns {Array<object>}
+ */
+function parseMultistatus(xml, requestedPath) {
+    const doc = new DOMParser().parseFromString(xml, 'text/xml')
+    const normalizedRequested = requestedPath.split('/').filter(s => s !== '').join('/')
+    const entries = []
+    for (const response of doc.getElementsByTagName('*')) {
+        if (davName(response) !== 'response') {
+            continue
+        }
+        const href = davText(response, 'href')
+        // The href is the absolute server path; the part after the WebDAV
+        // endpoint is the user-files-relative path (percent-encoded).
+        const match = href.match(/\/remote\.php\/webdav(\/.*)?$/)
+        if (match == null) {
+            continue
+        }
+        const relPath = (match[1] || '')
+            .split('/')
+            .filter(segment => segment !== '')
+            .map(decodeURIComponent)
+            .join('/')
+        // The collection lists itself first: not an entry of the folder.
+        if (relPath === normalizedRequested) {
+            continue
+        }
+        // Only the 200-status propstat holds real values; a 404 propstat lists
+        // the props the entry lacks. davText over the whole response would mix
+        // them up, so scope reads to the successful propstat.
+        let okProps = null
+        for (const el of response.getElementsByTagName('*')) {
+            if (davName(el) === 'propstat' && davText(el, 'status').includes('200')) {
+                okProps = el
+                break
+            }
+        }
+        if (okProps == null) {
+            continue
+        }
+        const mtimeText = davText(okProps, 'getlastmodified')
+        const mtime = mtimeText ? Date.parse(mtimeText) : 0
+        entries.push({
+            basename: relPath.split('/').pop(),
+            path: relPath,
+            isFolder: davIsCollection(okProps),
+            mime: davText(okProps, 'getcontenttype'),
+            size: Number(davText(okProps, 'getcontentlength')) || 0,
+            mtime: Number.isNaN(mtime) ? 0 : mtime,
+            fileid: davText(okProps, 'fileid'),
+        })
+    }
+    return entries
+}
+
+/**
+ * Thumbnail URL for an arbitrary user file, via Nextcloud's core preview
+ * endpoint (the app's own preview route only serves in-album assets).
+ * `a=1` keeps the aspect ratio; the chooser tile crops with object-fit.
+ *
+ * @param {string} fileid - the file's oc:fileid as returned by listFolder
+ * @param {number} size - requested bounding box in pixels
+ * @returns {string}
+ */
+export function getPreviewUrl(fileid, size = 256) {
+    return generateUrl('/core/preview')
+        + '?fileId=' + encodeURIComponent(fileid)
+        + '&x=' + size + '&y=' + size + '&a=1'
+}

--- a/src/components/ImageChooserDialog.vue
+++ b/src/components/ImageChooserDialog.vue
@@ -1,0 +1,317 @@
+<template>
+    <NcModal size="large" :name="sTitle" @close="$emit('close')">
+        <div class="chooser-dialog">
+            <div class="chooser-header">
+                <NcBreadcrumbs class="chooser-crumbs">
+                    <NcBreadcrumb :name="sAllFiles" :title="sAllFiles"
+                        :disable-drop="true" @click="browse('')">
+                        <template #icon>
+                            <Home :size="20" />
+                        </template>
+                    </NcBreadcrumb>
+                    <NcBreadcrumb v-for="crumb in crumbs" :key="crumb.path"
+                        :name="crumb.name" :title="crumb.name"
+                        :disable-drop="true" @click="browse(crumb.path)" />
+                </NcBreadcrumbs>
+                <NcButton :disabled="saving || loading"
+                    :aria-label="sUpload" :title="sUpload"
+                    v-on:click="$refs.fileInput.click()">
+                    <template #icon>
+                        <UploadIcon :size="20" />
+                    </template>
+                    {{ sUpload }}
+                </NcButton>
+                <!-- Hidden native picker behind the upload button; `accept`
+                     narrows the OS dialog to the mimetypes albums support. -->
+                <input ref="fileInput" type="file" class="chooser-file-input"
+                    :accept="acceptMimes" v-on:change="onFileChosen" />
+            </div>
+
+            <div class="chooser-body">
+                <div v-if="loading" class="chooser-center">
+                    <NcLoadingIcon :size="44" />
+                </div>
+                <NcEmptyContent v-else-if="entries.length === 0" :name="sEmpty">
+                    <template #icon>
+                        <ImageIcon />
+                    </template>
+                </NcEmptyContent>
+                <ul v-else class="chooser-grid" :aria-label="sTitle">
+                    <li v-for="entry in entries" :key="entry.path">
+                        <button v-if="entry.isFolder" type="button"
+                            class="chooser-tile chooser-folder"
+                            :disabled="saving" v-on:click="browse(entry.path)">
+                            <Folder :size="48" />
+                            <span class="chooser-name">{{ entry.basename }}</span>
+                        </button>
+                        <button v-else type="button"
+                            class="chooser-tile chooser-image"
+                            :class="{ selected: selectedPath === entry.path }"
+                            :aria-pressed="String(selectedPath === entry.path)"
+                            :disabled="saving"
+                            v-on:click="select(entry)" v-on:dblclick="choose(entry)">
+                            <img v-if="!failedPreviews[entry.path]" class="chooser-thumb"
+                                :src="previewUrl(entry)" :alt="entry.basename"
+                                loading="lazy"
+                                v-on:error="failedPreviews[entry.path] = true" />
+                            <ImageIcon v-else :size="48" />
+                            <span class="chooser-name">{{ entry.basename }}</span>
+                        </button>
+                    </li>
+                </ul>
+            </div>
+
+            <div class="chooser-footer">
+                <div class="chooser-footer-spacer"></div>
+                <NcButton :disabled="saving" v-on:click="$emit('close')">
+                    {{ sCancel }}
+                </NcButton>
+                <NcButton variant="primary" :disabled="saving || selectedEntry == null"
+                    v-on:click="choose(selectedEntry)">
+                    <template #icon>
+                        <NcLoadingIcon v-if="saving" :size="20" />
+                        <Check v-else :size="20" />
+                    </template>
+                    {{ sChoose }}
+                </NcButton>
+            </div>
+        </div>
+    </NcModal>
+</template>
+
+<script>
+
+import { NcModal, NcButton, NcLoadingIcon, NcEmptyContent, NcBreadcrumbs, NcBreadcrumb } from '@nextcloud/vue'
+import Home from 'vue-material-design-icons/Home.vue'
+import Folder from 'vue-material-design-icons/Folder.vue'
+import UploadIcon from 'vue-material-design-icons/Upload.vue'
+import ImageIcon from 'vue-material-design-icons/Image.vue'
+import Check from 'vue-material-design-icons/Check.vue'
+import { showError } from '@nextcloud/dialogs'
+import { listFolder, getPreviewUrl, IMAGE_MIMES } from '../api/davApi.js'
+
+export default {
+    props: {
+        // True while the album is linking/uploading the chosen image; freezes
+        // every control so nothing can be chosen twice (same contract as
+        // PaintDialog's saving prop).
+        "saving": Boolean,
+    },
+    emits: ['close', 'pick', 'upload'],
+    data: function() {
+        return {
+            "currentPath": "",
+            "entries": [],
+            "loading": false,
+            "selectedPath": null,
+            // Paths whose thumbnail failed to load (no preview provider):
+            // their tiles fall back to a generic image icon.
+            "failedPreviews": {},
+            "acceptMimes": IMAGE_MIMES.join(','),
+            "sTitle": t("souvenirs", "Choose an image"),
+            "sAllFiles": t("souvenirs", "All files"),
+            "sUpload": t("souvenirs", "Upload"),
+            "sCancel": t("souvenirs", "Cancel"),
+            "sChoose": t("souvenirs", "Choose"),
+            "sEmpty": t("souvenirs", "No images in this folder."),
+        }
+    },
+    components: {
+        NcModal,
+        NcButton,
+        NcLoadingIcon,
+        NcEmptyContent,
+        NcBreadcrumbs,
+        NcBreadcrumb,
+        Home,
+        Folder,
+        UploadIcon,
+        ImageIcon,
+        Check,
+    },
+    computed: {
+        'crumbs': function() {
+            // One breadcrumb per path segment, each carrying the cumulative
+            // path it navigates to. Empty at the files root.
+            var crumbs = [];
+            var path = "";
+            for (const segment of this.currentPath.split('/').filter(s => s !== '')) {
+                path = path === "" ? segment : path + '/' + segment;
+                crumbs.push({ name: segment, path: path });
+            }
+            return crumbs;
+        },
+        'selectedEntry': function() {
+            return this.entries.find(e => e.path === this.selectedPath) || null;
+        },
+    },
+    mounted: function() {
+        // Resume in the folder browsed last (this session); if it disappeared
+        // meanwhile, fall back to the files root once.
+        this.browse(lastBrowsedPath).then(ok => {
+            if (!ok && lastBrowsedPath !== "") {
+                lastBrowsedPath = "";
+                this.browse("");
+            }
+        });
+    },
+    methods: {
+        // Resolves to true on success; on failure shows a toast, keeps the
+        // current listing so the user is not stranded, and resolves to false
+        // (mounted() uses that for its root fallback).
+        browse: async function(path) {
+            this.loading = true;
+            this.selectedPath = null;
+            var listed;
+            try {
+                listed = await listFolder(path);
+            } catch (error) {
+                this.loading = false;
+                showError(t("souvenirs", "Could not open this folder."));
+                return false;
+            }
+            const folders = listed.filter(e => e.isFolder)
+                .sort((a, b) => a.basename.localeCompare(b.basename, undefined, { numeric: true, sensitivity: 'base' }));
+            // Most recent first within the folder (issue #31).
+            const images = listed.filter(e => !e.isFolder && IMAGE_MIMES.includes(e.mime))
+                .sort((a, b) => b.mtime - a.mtime);
+            this.entries = folders.concat(images);
+            this.currentPath = path;
+            this.failedPreviews = {};
+            this.loading = false;
+            lastBrowsedPath = path;
+            return true;
+        },
+        select: function(entry) {
+            // Clicking the selected tile again deselects it.
+            this.selectedPath = this.selectedPath === entry.path ? null : entry.path;
+        },
+        choose: function(entry) {
+            if (this.saving || entry == null) {
+                return;
+            }
+            this.$emit('pick', entry);
+        },
+        previewUrl: function(entry) {
+            return getPreviewUrl(entry.fileid);
+        },
+        onFileChosen: function(event) {
+            const file = event.target.files && event.target.files[0];
+            // Reset so picking the same file again re-fires `change`.
+            event.target.value = '';
+            if (!file) {
+                return;
+            }
+            if (!IMAGE_MIMES.includes(file.type)) {
+                showError(t("souvenirs", "This file is not a supported image."));
+                return;
+            }
+            this.$emit('upload', file);
+        },
+    },
+}
+
+// Folder shown when the chooser next opens, shared across dialog instances so
+// adding several images in a row does not restart from the files root.
+let lastBrowsedPath = "";
+
+</script>
+
+<style scoped>
+.chooser-dialog {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding: 16px;
+    height: min(80vh, 700px);
+}
+.chooser-header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+.chooser-crumbs {
+    flex: 1 1 auto;
+    min-width: 0;
+}
+/* The breadcrumbs flex-grow must not squeeze the upload button's label. */
+.chooser-header > .button-vue {
+    flex: 0 0 auto;
+}
+.chooser-file-input {
+    display: none;
+}
+.chooser-body {
+    flex: 1 1 auto;
+    overflow-y: auto;
+}
+.chooser-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+    gap: 8px;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+.chooser-tile {
+    position: relative;
+    width: 100%;
+    aspect-ratio: 1 / 1;
+    padding: 0;
+    overflow: hidden;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: none;
+    border-radius: var(--border-radius-large, 8px);
+    background-color: var(--color-background-hover);
+    cursor: pointer;
+}
+.chooser-tile:focus-visible {
+    outline: 2px solid var(--color-main-text);
+}
+.chooser-image.selected {
+    outline: 3px solid var(--color-primary-element);
+    outline-offset: -3px;
+}
+.chooser-thumb {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+.chooser-name {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    padding: 2px 6px;
+    font-size: 12px;
+    text-align: start;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    color: var(--color-main-text);
+    background-color: color-mix(in srgb, var(--color-main-background) 70%, transparent);
+}
+.chooser-folder {
+    flex-direction: column;
+    gap: 4px;
+}
+.chooser-folder .chooser-name {
+    position: static;
+    background: none;
+}
+.chooser-footer {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+.chooser-footer-spacer {
+    flex: 1 1 auto;
+}
+.chooser-center {
+    display: flex;
+    justify-content: center;
+    padding: 40px;
+}
+</style>

--- a/src/components/__tests__/ImageChooserDialog.test.js
+++ b/src/components/__tests__/ImageChooserDialog.test.js
@@ -1,0 +1,224 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+
+vi.mock('@nextcloud/dialogs', () => ({ showError: vi.fn() }))
+vi.mock('../../api/davApi.js', () => ({
+    IMAGE_MIMES: ['image/png', 'image/jpeg', 'image/gif', 'image/webp', 'image/bmp', 'image/tiff', 'image/svg+xml'],
+    listFolder: vi.fn(),
+    getPreviewUrl: vi.fn(fileid => 'preview-' + fileid),
+}))
+
+import { showError } from '@nextcloud/dialogs'
+import { listFolder } from '../../api/davApi.js'
+import ImageChooserDialog from '../ImageChooserDialog.vue'
+
+// Let the async browse() in mounted() settle.
+function flushBrowse() {
+    return new Promise(resolve => setTimeout(resolve, 0))
+}
+
+const folderB = { basename: 'b-folder', path: 'b-folder', isFolder: true, mime: '', size: 0, mtime: 500, fileid: '1' }
+const folderA = { basename: 'A-folder', path: 'A-folder', isFolder: true, mime: '', size: 0, mtime: 400, fileid: '2' }
+const oldImage = { basename: 'old.jpg', path: 'old.jpg', isFolder: false, mime: 'image/jpeg', size: 10, mtime: 1000, fileid: '10' }
+const newImage = { basename: 'new.png', path: 'new.png', isFolder: false, mime: 'image/png', size: 20, mtime: 2000, fileid: '11' }
+const notImage = { basename: 'doc.pdf', path: 'doc.pdf', isFolder: false, mime: 'application/pdf', size: 30, mtime: 3000, fileid: '12' }
+
+const ROOT_LISTING = [oldImage, folderB, notImage, newImage, folderA]
+
+async function mountDialog(props = {}) {
+    listFolder.mockReset()
+    listFolder.mockResolvedValue(ROOT_LISTING)
+    showError.mockClear()
+    const wrapper = mount(ImageChooserDialog, {
+        attachTo: document.body,
+        props: { saving: false, ...props },
+        global: {
+            stubs: {
+                // The modal shell and breadcrumb chrome are not under test;
+                // slot-passing stubs keep their content reachable.
+                NcModal: { template: '<div class="modal-stub"><slot /></div>' },
+                NcBreadcrumbs: { template: '<div class="crumbs-stub"><slot /></div>' },
+                NcBreadcrumb: {
+                    props: ['name'],
+                    template: '<button class="crumb-stub" @click="$emit(\'click\')">{{ name }}</button>',
+                },
+                NcEmptyContent: { props: ['name'], template: '<div class="empty-stub">{{ name }}</div>' },
+            },
+        },
+    })
+    await flushBrowse()
+    return wrapper
+}
+
+describe('ImageChooserDialog', () => {
+    beforeEach(async () => {
+        // The module remembers the last browsed folder across mounts: reset it
+        // by mounting once and navigating home via the root crumb when needed.
+    })
+
+    it('lists folders first (alphabetical), then images newest-first, other mimes dropped', async () => {
+        const wrapper = await mountDialog()
+        // Make the memory-dependent start deterministic: go to the root crumb.
+        await wrapper.find('.crumb-stub').trigger('click')
+        await flushBrowse()
+        const names = wrapper.findAll('.chooser-name').map(n => n.text())
+        expect(names).toEqual(['A-folder', 'b-folder', 'new.png', 'old.jpg'])
+        expect(names).not.toContain('doc.pdf')
+        wrapper.unmount()
+    })
+
+    it('navigates into a folder and grows the breadcrumbs', async () => {
+        const wrapper = await mountDialog()
+        await wrapper.find('.crumb-stub').trigger('click')
+        await flushBrowse()
+        listFolder.mockResolvedValue([newImage])
+        await wrapper.find('.chooser-folder').trigger('click')
+        await flushBrowse()
+        expect(listFolder).toHaveBeenLastCalledWith('A-folder')
+        const crumbs = wrapper.findAll('.crumb-stub').map(c => c.text())
+        expect(crumbs).toContain('A-folder')
+        wrapper.unmount()
+    })
+
+    it('navigates back through a breadcrumb click', async () => {
+        const wrapper = await mountDialog()
+        await wrapper.find('.crumb-stub').trigger('click')
+        await flushBrowse()
+        listFolder.mockResolvedValue([newImage])
+        await wrapper.find('.chooser-folder').trigger('click')
+        await flushBrowse()
+        listFolder.mockResolvedValue(ROOT_LISTING)
+        await wrapper.find('.crumb-stub').trigger('click') // root crumb
+        await flushBrowse()
+        expect(listFolder).toHaveBeenLastCalledWith('')
+        expect(wrapper.findAll('.chooser-folder')).toHaveLength(2)
+        wrapper.unmount()
+    })
+
+    it('remembers the last browsed folder across dialog instances', async () => {
+        const first = await mountDialog()
+        await first.find('.crumb-stub').trigger('click')
+        await flushBrowse()
+        listFolder.mockResolvedValue([newImage])
+        await first.find('.chooser-folder').trigger('click')
+        await flushBrowse()
+        first.unmount()
+        const second = await mountDialog()
+        expect(listFolder).toHaveBeenCalledWith('A-folder')
+        second.unmount()
+        // Leave the module memory at the root for the other tests.
+        const third = await mountDialog()
+        await third.find('.crumb-stub').trigger('click')
+        await flushBrowse()
+        third.unmount()
+    })
+
+    it('falls back to the files root when the remembered folder fails to list', async () => {
+        const first = await mountDialog()
+        await first.find('.crumb-stub').trigger('click')
+        await flushBrowse()
+        listFolder.mockResolvedValue([newImage])
+        await first.find('.chooser-folder').trigger('click')
+        await flushBrowse()
+        first.unmount()
+        listFolder.mockReset()
+        listFolder.mockRejectedValueOnce(new Error('gone'))
+        listFolder.mockResolvedValue(ROOT_LISTING)
+        showError.mockClear()
+        const second = mount(ImageChooserDialog, {
+            props: { saving: false },
+            global: { stubs: { NcModal: { template: '<div><slot /></div>' }, NcBreadcrumbs: { template: '<div><slot /></div>' }, NcBreadcrumb: { props: ['name'], template: '<button class="crumb-stub">{{ name }}</button>' }, NcEmptyContent: true } },
+        })
+        await flushBrowse()
+        expect(listFolder).toHaveBeenNthCalledWith(1, 'A-folder')
+        expect(listFolder).toHaveBeenNthCalledWith(2, '')
+        expect(showError).toHaveBeenCalled()
+        second.unmount()
+    })
+
+    it('disables Choose without a selection and emits pick once one is made', async () => {
+        const wrapper = await mountDialog()
+        const chooseButton = wrapper.findAll('button').filter(b => b.text() === 'Choose')[0]
+        expect(chooseButton.attributes('disabled')).toBeDefined()
+        const tile = wrapper.findAll('.chooser-image')[0] // new.png (newest first)
+        await tile.trigger('click')
+        expect(tile.attributes('aria-pressed')).toBe('true')
+        expect(chooseButton.attributes('disabled')).toBeUndefined()
+        await chooseButton.trigger('click')
+        expect(wrapper.emitted('pick')).toHaveLength(1)
+        expect(wrapper.emitted('pick')[0][0]).toMatchObject({ basename: 'new.png' })
+        wrapper.unmount()
+    })
+
+    it('deselects when the selected tile is clicked again', async () => {
+        const wrapper = await mountDialog()
+        const tile = wrapper.findAll('.chooser-image')[0]
+        await tile.trigger('click')
+        await tile.trigger('click')
+        expect(tile.attributes('aria-pressed')).toBe('false')
+        wrapper.unmount()
+    })
+
+    it('emits pick directly on double-click', async () => {
+        const wrapper = await mountDialog()
+        await wrapper.findAll('.chooser-image')[1].trigger('dblclick')
+        expect(wrapper.emitted('pick')[0][0]).toMatchObject({ basename: 'old.jpg' })
+        wrapper.unmount()
+    })
+
+    it('restricts the hidden input to image mimetypes and emits upload with the file', async () => {
+        const wrapper = await mountDialog()
+        const input = wrapper.find('input[type=file]')
+        expect(input.attributes('accept')).toContain('image/jpeg')
+        const file = new File(['bytes'], 'photo.jpg', { type: 'image/jpeg' })
+        Object.defineProperty(input.element, 'files', { value: [file], configurable: true })
+        await input.trigger('change')
+        expect(wrapper.emitted('upload')).toHaveLength(1)
+        expect(wrapper.emitted('upload')[0][0]).toBe(file)
+        wrapper.unmount()
+    })
+
+    it('rejects a non-image file with an error toast and no upload event', async () => {
+        const wrapper = await mountDialog()
+        const input = wrapper.find('input[type=file]')
+        const file = new File(['bytes'], 'doc.pdf', { type: 'application/pdf' })
+        Object.defineProperty(input.element, 'files', { value: [file], configurable: true })
+        await input.trigger('change')
+        expect(showError).toHaveBeenCalled()
+        expect(wrapper.emitted('upload')).toBeUndefined()
+        wrapper.unmount()
+    })
+
+    it('freezes every control while saving', async () => {
+        const wrapper = await mountDialog({ saving: true })
+        for (const button of wrapper.findAll('.chooser-tile')) {
+            expect(button.attributes('disabled')).toBeDefined()
+        }
+        const labels = ['Upload', 'Cancel', 'Choose']
+        for (const label of labels) {
+            const button = wrapper.findAll('button').filter(b => b.text() === label)[0]
+            expect(button.attributes('disabled')).toBeDefined()
+        }
+        wrapper.unmount()
+    })
+
+    it('keeps the current listing and shows an error when navigation fails', async () => {
+        const wrapper = await mountDialog()
+        listFolder.mockRejectedValueOnce(new Error('forbidden'))
+        await wrapper.find('.chooser-folder').trigger('click')
+        await flushBrowse()
+        expect(showError).toHaveBeenCalled()
+        expect(wrapper.findAll('.chooser-image')).toHaveLength(2)
+        wrapper.unmount()
+    })
+
+    it('swaps a broken thumbnail for the fallback icon', async () => {
+        const wrapper = await mountDialog()
+        const img = wrapper.find('.chooser-thumb')
+        expect(img.attributes('src')).toBe('preview-11')
+        await img.trigger('error')
+        const tile = wrapper.findAll('.chooser-image')[0]
+        expect(tile.find('.chooser-thumb').exists()).toBe(false)
+        wrapper.unmount()
+    })
+})

--- a/src/components/album.vue
+++ b/src/components/album.vue
@@ -65,6 +65,9 @@
             :elements="paintPage.elements" :album-path="path" :element-margin="elementMargin"
             :saving="paintSaving" v-on:close="closePaint" v-on:confirm="onPaintConfirm">
         </paint-dialog>
+        <image-chooser-dialog v-if="imageChooserPageId != null" :saving="imageChooserSaving"
+            v-on:close="closeImageChooser" v-on:pick="onImagePick" v-on:upload="onImageUpload">
+        </image-chooser-dialog>
         <NcModal v-if="downloadModal" @close="closeDownload" size="small">
             <p class="center">{{ sDownloadZip }}</p>
             <div v-if="!downloadActive" class="downloadIcon center" v-on:click="download"></div>
@@ -88,7 +91,8 @@ import { isElementDrag } from '../utils/elementDrag.js'
 import { cycleLayout } from '../utils/tilePageLayout.js'
 import { updatePage, searchAsset, cleanAssets, createPage, deletePage, movePage, probeAsset, uploadAsset } from '../api/albumApi.js'
 import PaintDialog from './PaintDialog.vue'
-import { getFilePickerBuilder, showError } from '@nextcloud/dialogs'
+import ImageChooserDialog from './ImageChooserDialog.vue'
+import { showError } from '@nextcloud/dialogs'
 import '@nextcloud/dialogs/style.css'
 import Pencil from 'vue-material-design-icons/Pencil.vue'
 import PencilOff from 'vue-material-design-icons/PencilOff.vue'
@@ -141,6 +145,9 @@ export default {
             // and whether its confirmed drawing is being uploaded/persisted.
             "paintPageId": null,
             "paintSaving": false,
+            // Same pair for the image chooser dialog.
+            "imageChooserPageId": null,
+            "imageChooserSaving": false,
             // Timestamp of the last page turn triggered by dragging an element
             // near the album edge (throttles the edge navigation).
             "dragNavLast": 0,
@@ -687,37 +694,22 @@ export default {
             // Best-effort GC of assets orphaned by dropped paint elements.
             cleanAssets(this.albumId).catch(() => {});
         },
-        onAddImage: async function(pageId) {
-            var index = this.pages.findIndex(p => p.id === pageId);
-            if (index < 0) {
+        onAddImage: function(pageId) {
+            this.imageChooserSaving = false;
+            this.imageChooserPageId = pageId;
+        },
+        closeImageChooser: function() {
+            // Ignore the dialog's close while a chosen image is being saved.
+            if (!this.imageChooserSaving) {
+                this.imageChooserPageId = null;
+            }
+        },
+        onImagePick: async function(entry) {
+            var index = this.pages.findIndex(p => p.id === this.imageChooserPageId);
+            if (index < 0 || this.imageChooserSaving) {
                 return;
             }
-            // Browse the user's existing Nextcloud files and pick one image.
-            var node;
-            try {
-                const picker = getFilePickerBuilder(t("souvenirs","Choose an image"))
-                    .setMimeTypeFilter(["image/png","image/jpeg","image/gif","image/webp","image/bmp","image/tiff","image/svg+xml"])
-                    .setMultiSelect(false)
-                    .allowDirectories(false)
-                    // Without an explicit confirm button the picker shows no way to
-                    // validate a selection, so pickNodes() would never resolve.
-                    .setButtonFactory((nodes) => [{
-                        label: t("souvenirs","Choose"),
-                        variant: "primary",
-                        disabled: nodes.length === 0,
-                        callback: () => {},
-                    }])
-                    .build();
-                const nodes = await picker.pickNodes();
-                node = Array.isArray(nodes) ? nodes[0] : nodes;
-            } catch (e) {
-                // The picker rejects when closed without a selection: ignore.
-                return;
-            }
-            if (node == null) {
-                return;
-            }
-            const file = { name: node.basename, size: node.size, mime: node.mime };
+            const file = { name: entry.basename, size: entry.size, mime: entry.mime };
             if (!file.size) {
                 showError(t("souvenirs","Could not read the selected file."));
                 return;
@@ -725,22 +717,62 @@ export default {
             // Build the element first so we know the in-album asset path to link,
             // then ask the backend to link the picked file to it (no copy/upload).
             const element = buildImageElement(file);
-            var res;
+            this.imageChooserSaving = true;
+            var updatedPage;
             try {
-                res = await searchAsset(this.albumId, element.image, file.name, file.size);
-            } catch (e) {
+                var res = await searchAsset(this.albumId, element.image, file.name, file.size);
+                if (res == null || res.status !== "found") {
+                    // Keep the dialog open so the user can pick another file.
+                    this.imageChooserSaving = false;
+                    showError(t("souvenirs","Could not link the selected image. It must be located outside the Souvenirs albums folder."));
+                    return;
+                }
+                updatedPage = addElement(this.pages[index], element);
+                await updatePage(this.albumId, updatedPage);
+            } catch (error) {
+                this.imageChooserSaving = false;
                 showError(t("souvenirs","Could not add the image."));
                 return;
             }
-            if (res == null || res.status !== "found") {
-                showError(t("souvenirs","Could not link the selected image. It must be located outside the Souvenirs albums folder."));
+            this.pages.splice(index, 1, updatedPage);
+            this.imageChooserSaving = false;
+            this.imageChooserPageId = null;
+        },
+        onImageUpload: async function(file) {
+            var index = this.pages.findIndex(p => p.id === this.imageChooserPageId);
+            if (index < 0 || this.imageChooserSaving) {
                 return;
             }
-            const updatedPage = addElement(this.pages[index], element);
+            const element = buildImageElement({ name: file.name, size: file.size, mime: file.type });
+            this.imageChooserSaving = true;
+            var updatedPage;
+            try {
+                // Same upload flow as the paint dialog (and the Android app):
+                // the probe returns where the asset lives under the user's files
+                // root, the bytes go up over native WebDAV, and the server must
+                // confirm the file landed before the page starts referencing it.
+                var probe = await probeAsset(this.albumId, element.image);
+                if (probe == null || !probe.path) {
+                    throw new Error("assetprobe returned no upload path");
+                }
+                await uploadAsset(probe.path, file);
+                var check = await probeAsset(this.albumId, element.image);
+                if (check == null || check.status !== "ok") {
+                    throw new Error("uploaded asset not found in the album");
+                }
+                updatedPage = addElement(this.pages[index], element);
+                await updatePage(this.albumId, updatedPage);
+            } catch (error) {
+                // Keep the dialog open so the user can retry; GC any bytes that
+                // landed before the failure (the element was never persisted).
+                this.imageChooserSaving = false;
+                showError(t("souvenirs","Could not upload the image."));
+                cleanAssets(this.albumId).catch(() => {});
+                return;
+            }
             this.pages.splice(index, 1, updatedPage);
-            updatePage(this.albumId, updatedPage).catch(error => {
-                showError(t("souvenirs","Could not save the added image."));
-            });
+            this.imageChooserSaving = false;
+            this.imageChooserPageId = null;
         },
         resizeEventHandler: function(e) {
             if (window.innerHeight > window.innerWidth) {
@@ -763,6 +795,7 @@ export default {
         Videofull: Videofull,
         AudioPlayer: AudioPlayer,
         "paint-dialog": PaintDialog,
+        "image-chooser-dialog": ImageChooserDialog,
         NcModal,
         NcProgressBar,
         NcActions,


### PR DESCRIPTION
Fixes #31.

## What

Replaces the stock `@nextcloud/dialogs` file picker used to add an image to a page in edit mode with a custom mosaic chooser:

- **Folder browser with thumbnail mosaic**: breadcrumb navigation of the user's Nextcloud files; folders first (alphabetical), then images as large square thumbnails sorted **most-recent-first** within the folder. Single-select (multi-select is left for #36); double-click chooses directly.
- **Direct upload button**: picks a local image and pushes it straight into the album using the existing `assetprobe` + native WebDAV PUT flow (same as the Android app's `pushAsset` and the paint feature — no new apiv2 upload endpoint).
- **Unchanged base behavior**: choosing an existing server file still links it via `assetsearch` (`.lnk`, no copy). On any failure the dialog stays open with an error toast so the selection isn't lost.

## How

- `src/api/davApi.js` (new): hand-rolled WebDAV `PROPFIND` listing over plain `fetch` (consistent with `albumApi.js`), plus `/core/preview?fileId=` thumbnail URLs; files without a preview fall back to a generic icon.
- `src/components/ImageChooserDialog.vue` (new): `NcModal` dialog modeled on `PaintDialog.vue` — emits `pick`/`upload`/`close`, a `saving` prop freezes controls while persisting, and it remembers the last browsed folder within the session.
- `src/components/album.vue`: `onAddImage` opens the dialog; new `onImagePick`/`onImageUpload` handlers own persistence (probe → PUT → confirm re-probe → `updatePage`, mirroring `onPaintConfirm`).

## Tests

- `davApi.test.js` (9) and `ImageChooserDialog.test.js` (13); full suite 203/203 green.
- Verified end-to-end on a live Nextcloud: browse/breadcrumbs, newest-first sort, pick→`.lnk` created, upload→bytes land in `data/`, in-album files correctly refused with a toast, preview-less files fall back to an icon, last folder remembered.

