### PR TITLE
Add videos to albums from the web editor (#32)

### DIFF
--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -3,6 +3,7 @@ namespace OCA\Souvenirs\Controller;
 
 use OCP\IRequest;
 use OCP\IConfig;
+use OCP\AppFramework\Http\ContentSecurityPolicy;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\Controller;
@@ -39,7 +40,13 @@ class PageController extends Controller {
 		try { 
 			$albumsDir = Utils::getAlbumsNode($this->config, $this->userId, $this->appName, $this->userFolder);
 			if($albumsDir instanceof \OCP\Files\Folder) {
-				return new TemplateResponse('souvenirs','index', array("isDev" => $isDev));
+				$response = new TemplateResponse('souvenirs','index', array("isDev" => $isDev));
+				// The video poster capture (issue #32) plays the picked video
+				// from an object URL, which the default CSP media-src blocks.
+				$csp = new ContentSecurityPolicy();
+				$csp->addAllowedMediaDomain("blob:");
+				$response->setContentSecurityPolicy($csp);
+				return $response;
 			} else {
 				return new TemplateResponse('souvenirs','error',array('msg' => 'Wrong album path {$albumsDir->getPath()}'));
 			}

--- a/src/api/__tests__/davApi.test.js
+++ b/src/api/__tests__/davApi.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { listFolder, getPreviewUrl, IMAGE_MIMES } from '../davApi.js'
+import { listFolder, getPreviewUrl, getFileBlob, IMAGE_MIMES, VIDEO_MIMES } from '../davApi.js'
 
 // A realistic Nextcloud PROPFIND multistatus: the listed collection itself
 // (must be skipped), a subfolder, and two images — one with a space + UTF-8
@@ -144,6 +144,38 @@ describe('davApi', () => {
             expect(IMAGE_MIMES).toContain('image/jpeg')
             expect(IMAGE_MIMES).toContain('image/svg+xml')
             expect(IMAGE_MIMES).toHaveLength(7)
+        })
+    })
+
+    describe('VIDEO_MIMES', () => {
+        it('covers the common HTML5-playable containers (issue #32)', () => {
+            expect(VIDEO_MIMES).toContain('video/mp4')
+            expect(VIDEO_MIMES).toContain('video/webm')
+            // No overlap with the image list: the chooser branches on it.
+            for (const mime of VIDEO_MIMES) {
+                expect(IMAGE_MIMES).not.toContain(mime)
+            }
+        })
+    })
+
+    describe('getFileBlob', () => {
+        it('GETs the encoded WebDAV URL with the request token and returns the blob', async () => {
+            const blob = new Blob(['video-bytes'])
+            globalThis.fetch = vi.fn(() => Promise.resolve({
+                ok: true,
+                status: 200,
+                blob: () => Promise.resolve(blob),
+            }))
+            const result = await getFileBlob('Photos/Vacances 2024/clip été.mp4')
+            const [url, options] = globalThis.fetch.mock.calls[0]
+            expect(url).toMatch(/\/remote\.php\/webdav\/Photos\/Vacances%202024\/clip%20%C3%A9t%C3%A9.mp4$/)
+            expect(options.headers.requesttoken).toBe('test-token')
+            expect(result).toBe(blob)
+        })
+
+        it('rejects on an HTTP error status', async () => {
+            globalThis.fetch = vi.fn(() => Promise.resolve({ ok: false, status: 404 }))
+            await expect(getFileBlob('gone.mp4')).rejects.toThrow('404')
         })
     })
 })

--- a/src/api/davApi.js
+++ b/src/api/davApi.js
@@ -27,6 +27,20 @@ export const IMAGE_MIMES = [
 ]
 
 /**
+ * The video mimetypes an album element can play (issue #32): what HTML5
+ * `<video>` commonly decodes — which the poster capture also relies on — and
+ * the Android app records/picks. Shared by the chooser's grid filter and its
+ * upload input's `accept` attribute, like IMAGE_MIMES.
+ */
+export const VIDEO_MIMES = [
+    'video/mp4',
+    'video/webm',
+    'video/ogg',
+    'video/quicktime',
+    'video/x-matroska',
+]
+
+/**
  * Encode a user-files-relative path for use in a WebDAV URL: per-segment
  * percent-encoding, empty segments dropped so the URL never contains a double
  * slash (same rules as albumApi.js uploadAsset).
@@ -116,6 +130,25 @@ export function listFolder(path) {
         }
         return response.text()
     }).then(xml => parseMultistatus(xml, path))
+}
+
+/**
+ * Download a user file over WebDAV (plain GET, same auth as listFolder). Used
+ * to capture a poster frame from a video already on the server: a `<video>`
+ * src cannot carry the CSRF token header, so the bytes are fetched first.
+ *
+ * @param {string} path - file path relative to the user's files root
+ * @returns {Promise<Blob>}
+ */
+export function getFileBlob(path) {
+    return fetch(generateRemoteUrl('webdav') + '/' + encodePath(path), {
+        headers: { 'requesttoken': OC.requestToken },
+    }).then(response => {
+        if (!response.ok) {
+            throw new Error('WebDAV GET failed with status ' + response.status)
+        }
+        return response.blob()
+    })
 }
 
 /**

--- a/src/components/ImageChooserDialog.vue
+++ b/src/components/ImageChooserDialog.vue
@@ -54,7 +54,11 @@
                                 :src="previewUrl(entry)" :alt="entry.basename"
                                 loading="lazy"
                                 v-on:error="failedPreviews[entry.path] = true" />
+                            <VideoIcon v-else-if="isVideo(entry)" :size="48" />
                             <ImageIcon v-else :size="48" />
+                            <span v-if="isVideo(entry)" class="chooser-video-badge">
+                                <PlayCircleOutline :size="24" />
+                            </span>
                             <span class="chooser-name">{{ entry.basename }}</span>
                         </button>
                     </li>
@@ -86,9 +90,14 @@ import Home from 'vue-material-design-icons/Home.vue'
 import Folder from 'vue-material-design-icons/Folder.vue'
 import UploadIcon from 'vue-material-design-icons/Upload.vue'
 import ImageIcon from 'vue-material-design-icons/Image.vue'
+import VideoIcon from 'vue-material-design-icons/Video.vue'
+import PlayCircleOutline from 'vue-material-design-icons/PlayCircleOutline.vue'
 import Check from 'vue-material-design-icons/Check.vue'
 import { showError } from '@nextcloud/dialogs'
-import { listFolder, getPreviewUrl, IMAGE_MIMES } from '../api/davApi.js'
+import { listFolder, getPreviewUrl, IMAGE_MIMES, VIDEO_MIMES } from '../api/davApi.js'
+
+// Everything the chooser offers: images and, since issue #32, videos.
+const MEDIA_MIMES = IMAGE_MIMES.concat(VIDEO_MIMES)
 
 export default {
     props: {
@@ -107,13 +116,13 @@ export default {
             // Paths whose thumbnail failed to load (no preview provider):
             // their tiles fall back to a generic image icon.
             "failedPreviews": {},
-            "acceptMimes": IMAGE_MIMES.join(','),
-            "sTitle": t("souvenirs", "Choose an image"),
+            "acceptMimes": MEDIA_MIMES.join(','),
+            "sTitle": t("souvenirs", "Choose an image or a video"),
             "sAllFiles": t("souvenirs", "All files"),
             "sUpload": t("souvenirs", "Upload"),
             "sCancel": t("souvenirs", "Cancel"),
             "sChoose": t("souvenirs", "Choose"),
-            "sEmpty": t("souvenirs", "No images in this folder."),
+            "sEmpty": t("souvenirs", "No images or videos in this folder."),
         }
     },
     components: {
@@ -127,6 +136,8 @@ export default {
         Folder,
         UploadIcon,
         ImageIcon,
+        VideoIcon,
+        PlayCircleOutline,
         Check,
     },
     computed: {
@@ -173,14 +184,17 @@ export default {
             const folders = listed.filter(e => e.isFolder)
                 .sort((a, b) => a.basename.localeCompare(b.basename, undefined, { numeric: true, sensitivity: 'base' }));
             // Most recent first within the folder (issue #31).
-            const images = listed.filter(e => !e.isFolder && IMAGE_MIMES.includes(e.mime))
+            const media = listed.filter(e => !e.isFolder && MEDIA_MIMES.includes(e.mime))
                 .sort((a, b) => b.mtime - a.mtime);
-            this.entries = folders.concat(images);
+            this.entries = folders.concat(media);
             this.currentPath = path;
             this.failedPreviews = {};
             this.loading = false;
             lastBrowsedPath = path;
             return true;
+        },
+        isVideo: function(entry) {
+            return VIDEO_MIMES.includes(entry.mime);
         },
         select: function(entry) {
             // Clicking the selected tile again deselects it.
@@ -202,8 +216,8 @@ export default {
             if (!file) {
                 return;
             }
-            if (!IMAGE_MIMES.includes(file.type)) {
-                showError(t("souvenirs", "This file is not a supported image."));
+            if (!MEDIA_MIMES.includes(file.type)) {
+                showError(t("souvenirs", "This file is not a supported image or video."));
                 return;
             }
             this.$emit('upload', file);
@@ -278,6 +292,15 @@ let lastBrowsedPath = "";
     width: 100%;
     height: 100%;
     object-fit: cover;
+}
+/* Play badge marking video tiles apart from image ones. */
+.chooser-video-badge {
+    position: absolute;
+    top: 4px;
+    right: 4px;
+    display: flex;
+    color: #ffffff;
+    filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.7));
 }
 .chooser-name {
     position: absolute;

--- a/src/components/__tests__/ImageChooserDialog.test.js
+++ b/src/components/__tests__/ImageChooserDialog.test.js
@@ -4,6 +4,7 @@ import { mount } from '@vue/test-utils'
 vi.mock('@nextcloud/dialogs', () => ({ showError: vi.fn() }))
 vi.mock('../../api/davApi.js', () => ({
     IMAGE_MIMES: ['image/png', 'image/jpeg', 'image/gif', 'image/webp', 'image/bmp', 'image/tiff', 'image/svg+xml'],
+    VIDEO_MIMES: ['video/mp4', 'video/webm', 'video/ogg', 'video/quicktime', 'video/x-matroska'],
     listFolder: vi.fn(),
     getPreviewUrl: vi.fn(fileid => 'preview-' + fileid),
 }))
@@ -22,8 +23,9 @@ const folderA = { basename: 'A-folder', path: 'A-folder', isFolder: true, mime: 
 const oldImage = { basename: 'old.jpg', path: 'old.jpg', isFolder: false, mime: 'image/jpeg', size: 10, mtime: 1000, fileid: '10' }
 const newImage = { basename: 'new.png', path: 'new.png', isFolder: false, mime: 'image/png', size: 20, mtime: 2000, fileid: '11' }
 const notImage = { basename: 'doc.pdf', path: 'doc.pdf', isFolder: false, mime: 'application/pdf', size: 30, mtime: 3000, fileid: '12' }
+const video = { basename: 'clip.mp4', path: 'clip.mp4', isFolder: false, mime: 'video/mp4', size: 40, mtime: 1500, fileid: '13' }
 
-const ROOT_LISTING = [oldImage, folderB, notImage, newImage, folderA]
+const ROOT_LISTING = [oldImage, folderB, notImage, newImage, folderA, video]
 
 async function mountDialog(props = {}) {
     listFolder.mockReset()
@@ -56,14 +58,30 @@ describe('ImageChooserDialog', () => {
         // by mounting once and navigating home via the root crumb when needed.
     })
 
-    it('lists folders first (alphabetical), then images newest-first, other mimes dropped', async () => {
+    it('lists folders first (alphabetical), then images and videos newest-first, other mimes dropped', async () => {
         const wrapper = await mountDialog()
         // Make the memory-dependent start deterministic: go to the root crumb.
         await wrapper.find('.crumb-stub').trigger('click')
         await flushBrowse()
         const names = wrapper.findAll('.chooser-name').map(n => n.text())
-        expect(names).toEqual(['A-folder', 'b-folder', 'new.png', 'old.jpg'])
+        expect(names).toEqual(['A-folder', 'b-folder', 'new.png', 'clip.mp4', 'old.jpg'])
         expect(names).not.toContain('doc.pdf')
+        wrapper.unmount()
+    })
+
+    it('marks video tiles with a play badge, image tiles without', async () => {
+        const wrapper = await mountDialog()
+        const tiles = wrapper.findAll('.chooser-image')
+        // newest-first: new.png, clip.mp4, old.jpg
+        expect(tiles[1].find('.chooser-video-badge').exists()).toBe(true)
+        expect(tiles[0].find('.chooser-video-badge').exists()).toBe(false)
+        wrapper.unmount()
+    })
+
+    it('emits pick with the video entry when a video is chosen', async () => {
+        const wrapper = await mountDialog()
+        await wrapper.findAll('.chooser-image')[1].trigger('dblclick')
+        expect(wrapper.emitted('pick')[0][0]).toMatchObject({ basename: 'clip.mp4', mime: 'video/mp4' })
         wrapper.unmount()
     })
 
@@ -161,15 +179,16 @@ describe('ImageChooserDialog', () => {
 
     it('emits pick directly on double-click', async () => {
         const wrapper = await mountDialog()
-        await wrapper.findAll('.chooser-image')[1].trigger('dblclick')
+        await wrapper.findAll('.chooser-image')[2].trigger('dblclick')
         expect(wrapper.emitted('pick')[0][0]).toMatchObject({ basename: 'old.jpg' })
         wrapper.unmount()
     })
 
-    it('restricts the hidden input to image mimetypes and emits upload with the file', async () => {
+    it('restricts the hidden input to media mimetypes and emits upload with the file', async () => {
         const wrapper = await mountDialog()
         const input = wrapper.find('input[type=file]')
         expect(input.attributes('accept')).toContain('image/jpeg')
+        expect(input.attributes('accept')).toContain('video/mp4')
         const file = new File(['bytes'], 'photo.jpg', { type: 'image/jpeg' })
         Object.defineProperty(input.element, 'files', { value: [file], configurable: true })
         await input.trigger('change')
@@ -178,7 +197,17 @@ describe('ImageChooserDialog', () => {
         wrapper.unmount()
     })
 
-    it('rejects a non-image file with an error toast and no upload event', async () => {
+    it('accepts a video file for upload', async () => {
+        const wrapper = await mountDialog()
+        const input = wrapper.find('input[type=file]')
+        const file = new File(['bytes'], 'clip.mp4', { type: 'video/mp4' })
+        Object.defineProperty(input.element, 'files', { value: [file], configurable: true })
+        await input.trigger('change')
+        expect(wrapper.emitted('upload')[0][0]).toBe(file)
+        wrapper.unmount()
+    })
+
+    it('rejects a non-media file with an error toast and no upload event', async () => {
         const wrapper = await mountDialog()
         const input = wrapper.find('input[type=file]')
         const file = new File(['bytes'], 'doc.pdf', { type: 'application/pdf' })
@@ -208,7 +237,7 @@ describe('ImageChooserDialog', () => {
         await wrapper.find('.chooser-folder').trigger('click')
         await flushBrowse()
         expect(showError).toHaveBeenCalled()
-        expect(wrapper.findAll('.chooser-image')).toHaveLength(2)
+        expect(wrapper.findAll('.chooser-image')).toHaveLength(3)
         wrapper.unmount()
     })
 

--- a/src/components/album.vue
+++ b/src/components/album.vue
@@ -94,8 +94,10 @@ import { NcLoadingIcon, NcActionInput, NcActionButton, NcActions, NcProgressBar,
 import Plus from 'vue-material-design-icons/Plus.vue'
 import JSZip from 'jszip'
 import { saveAs } from 'file-saver'
-import { setElementText, setElementGeometry, setElementPanZoom, removeElement, buildImageElement, buildTextElement, buildPage, addElement, swapElements, getPaintElement, setPagePaintElement, removePaintElements } from '../utils/albumEdit.js'
+import { setElementText, setElementGeometry, setElementPanZoom, removeElement, buildImageElement, buildVideoElement, buildTextElement, buildPage, addElement, swapElements, getPaintElement, setPagePaintElement, removePaintElements } from '../utils/albumEdit.js'
 import { isElementDrag } from '../utils/elementDrag.js'
+import { captureVideoPoster } from '../utils/videoPoster.js'
+import { getFileBlob, VIDEO_MIMES } from '../api/davApi.js'
 import { cycleLayout } from '../utils/tilePageLayout.js'
 import { updatePage, searchAsset, cleanAssets, createPage, deletePage, movePage, probeAsset, uploadAsset } from '../api/albumApi.js'
 import PaintDialog from './PaintDialog.vue'
@@ -724,6 +726,11 @@ export default {
             }
         },
         onImagePick: async function(entry) {
+            // The chooser offers images and videos (issue #32); a picked video
+            // goes through its own flow (VideoElement + poster capture).
+            if (VIDEO_MIMES.includes(entry.mime)) {
+                return this.onVideoPick(entry);
+            }
             var index = this.pages.findIndex(p => p.id === this.imageChooserPageId);
             if (index < 0 || this.imageChooserSaving) {
                 return;
@@ -758,6 +765,10 @@ export default {
             this.imageChooserPageId = null;
         },
         onImageUpload: async function(file) {
+            // Same split as onImagePick: uploaded videos have their own flow.
+            if (VIDEO_MIMES.includes(file.type)) {
+                return this.onVideoUpload(file);
+            }
             var index = this.pages.findIndex(p => p.id === this.imageChooserPageId);
             if (index < 0 || this.imageChooserSaving) {
                 return;
@@ -786,6 +797,113 @@ export default {
                 // landed before the failure (the element was never persisted).
                 this.imageChooserSaving = false;
                 showError(t("souvenirs","Could not upload the image."));
+                cleanAssets(this.albumId).catch(() => {});
+                return;
+            }
+            this.pages.splice(index, 1, updatedPage);
+            this.imageChooserSaving = false;
+            this.imageChooserPageId = null;
+        },
+        attachVideoPoster: async function(element, videoBlob) {
+            // Capture a poster frame of the video and upload it as the
+            // element's `image` asset (the Android app stores a generated
+            // thumbnail there too). Best-effort: any failure — undecodable
+            // codec, upload error — returns the element without a poster,
+            // which every consumer (web and Android) tolerates.
+            try {
+                var poster = await captureVideoPoster(videoBlob);
+                if (poster == null) {
+                    throw new Error("poster capture failed");
+                }
+                var probe = await probeAsset(this.albumId, element.image);
+                if (probe == null || !probe.path) {
+                    throw new Error("assetprobe returned no upload path");
+                }
+                await uploadAsset(probe.path, poster);
+                var check = await probeAsset(this.albumId, element.image);
+                if (check == null || check.status !== "ok") {
+                    throw new Error("uploaded poster not found in the album");
+                }
+                return element;
+            } catch (error) {
+                return { ...element, image: '' };
+            }
+        },
+        onVideoPick: async function(entry) {
+            var index = this.pages.findIndex(p => p.id === this.imageChooserPageId);
+            if (index < 0 || this.imageChooserSaving) {
+                return;
+            }
+            const file = { name: entry.basename, size: entry.size, mime: entry.mime };
+            if (!file.size) {
+                showError(t("souvenirs","Could not read the selected file."));
+                return;
+            }
+            // Same shape as onImagePick — link the picked file to the element's
+            // video asset (no copy/upload) — plus the poster capture, for which
+            // the video bytes are pulled once over WebDAV.
+            var element = buildVideoElement(file);
+            this.imageChooserSaving = true;
+            var updatedPage;
+            try {
+                var res = await searchAsset(this.albumId, element.video, file.name, file.size);
+                if (res == null || res.status !== "found") {
+                    // Keep the dialog open so the user can pick another file.
+                    this.imageChooserSaving = false;
+                    showError(t("souvenirs","Could not link the selected video. It must be located outside the Souvenirs albums folder."));
+                    return;
+                }
+                var blob = null;
+                try {
+                    blob = await getFileBlob(entry.path);
+                } catch (fetchError) {
+                    // No bytes, no poster: the element is still fully usable.
+                }
+                element = (blob != null)
+                    ? await this.attachVideoPoster(element, blob)
+                    : { ...element, image: '' };
+                updatedPage = addElement(this.pages[index], element);
+                await updatePage(this.albumId, updatedPage);
+            } catch (error) {
+                this.imageChooserSaving = false;
+                showError(t("souvenirs","Could not add the video."));
+                // GC the link/poster of the never-persisted element.
+                cleanAssets(this.albumId).catch(() => {});
+                return;
+            }
+            this.pages.splice(index, 1, updatedPage);
+            this.imageChooserSaving = false;
+            this.imageChooserPageId = null;
+        },
+        onVideoUpload: async function(file) {
+            var index = this.pages.findIndex(p => p.id === this.imageChooserPageId);
+            if (index < 0 || this.imageChooserSaving) {
+                return;
+            }
+            var element = buildVideoElement({ name: file.name, size: file.size, mime: file.type });
+            this.imageChooserSaving = true;
+            var updatedPage;
+            try {
+                // Same upload flow as images (and the Android app): probe for
+                // the WebDAV destination, upload the bytes, and have the server
+                // confirm the video landed before the page references it.
+                var probe = await probeAsset(this.albumId, element.video);
+                if (probe == null || !probe.path) {
+                    throw new Error("assetprobe returned no upload path");
+                }
+                await uploadAsset(probe.path, file);
+                var check = await probeAsset(this.albumId, element.video);
+                if (check == null || check.status !== "ok") {
+                    throw new Error("uploaded asset not found in the album");
+                }
+                element = await this.attachVideoPoster(element, file);
+                updatedPage = addElement(this.pages[index], element);
+                await updatePage(this.albumId, updatedPage);
+            } catch (error) {
+                // Keep the dialog open so the user can retry; GC any bytes that
+                // landed before the failure (the element was never persisted).
+                this.imageChooserSaving = false;
+                showError(t("souvenirs","Could not upload the video."));
                 cleanAssets(this.albumId).catch(() => {});
                 return;
             }

--- a/src/components/page.vue
+++ b/src/components/page.vue
@@ -46,7 +46,7 @@
                 <template #icon>
                     <Plus :size="20" />
                 </template>
-                {{ sAddImage }}
+                {{ sAddMedia }}
             </NcButton>
             <NcButton type="primary" v-on:click="onAddText">
                 <template #icon>
@@ -100,7 +100,8 @@ export default {
         return {
             "isFocus": false,
             "preloadScope": 5,
-            "sAddImage": t("souvenirs","Add image"),
+            // Images and, since issue #32, videos go through the same chooser.
+            "sAddMedia": t("souvenirs","Add media"),
             "sAddText": t("souvenirs","Add text"),
             "sPaint": t("souvenirs","Paint"),
             "sChangeLayout": t("souvenirs","Change layout"),

--- a/src/utils/__tests__/albumEdit.test.js
+++ b/src/utils/__tests__/albumEdit.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { setElementText, setElementGeometry, setElementPanZoom, relayoutElements, removeElement, buildImageElement, buildTextElement, buildPage, addElement, swapElements, getPaintElement, buildPaintElement, setPagePaintElement, removePaintElements } from '../albumEdit.js'
+import { setElementText, setElementGeometry, setElementPanZoom, relayoutElements, removeElement, buildImageElement, buildVideoElement, buildTextElement, buildPage, addElement, swapElements, getPaintElement, buildPaintElement, setPagePaintElement, removePaintElements } from '../albumEdit.js'
 
 describe('setElementText', () => {
     const makePage = () => ({
@@ -204,6 +204,40 @@ describe('buildImageElement', () => {
         const a = buildImageElement({ name: 'x.jpg', size: 1, mime: 'image/jpeg' })
         const b = buildImageElement({ name: 'x.jpg', size: 1, mime: 'image/jpeg' })
         expect(a.id).not.toBe(b.id)
+        expect(a.image).not.toBe(b.image)
+    })
+})
+
+describe('buildVideoElement', () => {
+    it('builds a VideoElement matching the on-disk schema (issue #32)', () => {
+        const el = buildVideoElement({ name: 'clip.MP4', size: 54321, mime: 'video/mp4' })
+        expect(el.class).toBe('VideoElement')
+        // name/size/mime keep the original VIDEO file's identity (asset reuse).
+        expect(el.name).toBe('clip.MP4')
+        expect(el.size).toBe(54321)
+        expect(el.mime).toBe('video/mp4')
+        expect(el.transformType).toBe(2)
+        expect(el.zoom).toBe(100)
+        expect(el.id).toBeTruthy()
+    })
+
+    it('stores the video under a generated uuid name keeping the extension', () => {
+        const el = buildVideoElement({ name: 'clip.MP4', size: 1, mime: 'video/mp4' })
+        expect(el.video).toMatch(/^data\/[0-9a-f-]+\.MP4$/)
+        expect(el.video).not.toContain('clip')
+    })
+
+    it('points image at a generated jpg poster asset, distinct from the video', () => {
+        const el = buildVideoElement({ name: 'clip.mp4', size: 1, mime: 'video/mp4' })
+        expect(el.image).toMatch(/^data\/[0-9a-f-]+\.jpg$/)
+        expect(el.image).not.toBe(el.video)
+    })
+
+    it('gives each call a distinct element id and asset paths', () => {
+        const a = buildVideoElement({ name: 'x.mp4', size: 1, mime: 'video/mp4' })
+        const b = buildVideoElement({ name: 'x.mp4', size: 1, mime: 'video/mp4' })
+        expect(a.id).not.toBe(b.id)
+        expect(a.video).not.toBe(b.video)
         expect(a.image).not.toBe(b.image)
     })
 })

--- a/src/utils/__tests__/videoPoster.test.js
+++ b/src/utils/__tests__/videoPoster.test.js
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { captureVideoPoster } from '../videoPoster.js'
+
+// happy-dom does not decode media, so only the failure paths are testable
+// here: the capture must resolve null (never reject) and release its object
+// URL. The happy path is covered by the e2e verification against a browser.
+describe('captureVideoPoster', () => {
+    let createdVideo
+
+    beforeEach(() => {
+        URL.createObjectURL = vi.fn(() => 'blob:video')
+        URL.revokeObjectURL = vi.fn()
+        const realCreate = document.createElement.bind(document)
+        vi.spyOn(document, 'createElement').mockImplementation(tag => {
+            const el = realCreate(tag)
+            if (tag === 'video') {
+                createdVideo = el
+            }
+            return el
+        })
+    })
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    it('resolves null when the video errors (undecodable codec)', async () => {
+        const promise = captureVideoPoster(new Blob(['not-a-video']))
+        createdVideo.dispatchEvent(new Event('error'))
+        await expect(promise).resolves.toBeNull()
+        expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:video')
+    })
+
+    it('resolves null after the timeout when nothing loads', async () => {
+        await expect(captureVideoPoster(new Blob(['x']), 20)).resolves.toBeNull()
+        expect(URL.revokeObjectURL).toHaveBeenCalled()
+    })
+
+    it('resolves null when no frame size is available after load', async () => {
+        const promise = captureVideoPoster(new Blob(['x']))
+        // happy-dom leaves videoWidth/videoHeight at 0 and duration NaN, so
+        // loadeddata goes straight to draw(), which must give up cleanly.
+        createdVideo.dispatchEvent(new Event('loadeddata'))
+        await expect(promise).resolves.toBeNull()
+    })
+})

--- a/src/utils/albumEdit.js
+++ b/src/utils/albumEdit.js
@@ -68,6 +68,43 @@ export function buildImageElement({ name, size, mime }) {
 }
 
 /**
+ * Build a fresh VideoElement for a picked Nextcloud file (issue #32). On disk
+ * (as in the Android app) a VideoElement is an ImageElement — whose `image` is a
+ * generated poster/thumbnail of the video — plus a `video` field holding the
+ * actual video asset. `name`/`size`/`mime` keep the ORIGINAL VIDEO file's
+ * identity, so the asset-reuse endpoints (assetsearch/clean) match the video,
+ * not the poster (which is generated, hence never present elsewhere).
+ * Geometry is left at full-page; the caller runs it through `addElement`.
+ *
+ * @param {object} file - the picked file: `{ name, size, mime }`
+ * @returns {object} a new VideoElement object (not yet placed in a page)
+ */
+export function buildVideoElement({ name, size, mime }) {
+    const dot = name.lastIndexOf('.')
+    const extension = dot >= 0 ? name.slice(dot) : ''
+    return {
+        class: 'VideoElement',
+        id: uuidv4(),
+        video: 'data/' + uuidv4() + extension,
+        // Poster frame captured from the video, stored as a JPEG asset. The
+        // caller blanks this field if the capture/upload fails (best-effort).
+        image: 'data/' + uuidv4() + '.jpg',
+        mime: mime,
+        name: name,
+        size: size,
+        offsetX: 0,
+        offsetY: 0,
+        zoom: 100,
+        transformType: 2, // IMG_ZOOMOFFSET (zoom 100 / no offset): cover-fit, matches the Android format
+        stop: false,
+        top: 0,
+        left: 0,
+        right: 100,
+        bottom: 100,
+    }
+}
+
+/**
  * Build a fresh, empty TextElement following the on-disk format produced by the
  * Android app. Geometry is left at full-page; the caller runs it through
  * `addElement` (which re-lays-out the page). The caption is filled in afterwards

--- a/src/utils/videoPoster.js
+++ b/src/utils/videoPoster.js
@@ -1,0 +1,87 @@
+/**
+ * Poster-frame capture for video elements (issue #32).
+ *
+ * The Android app stores a generated thumbnail as the VideoElement's `image`
+ * asset (ThumbnailUtils.createVideoThumbnail); the web equivalent is decoding
+ * a frame with an off-DOM `<video>` and drawing it on a canvas. This is
+ * best-effort by design: the returned promise NEVER rejects — a codec the
+ * browser cannot decode, a canvas failure or a timeout all resolve to null,
+ * and the caller saves the element without a poster.
+ */
+
+// A frame at t=0 is often black; aim ~1s in (or the middle of shorter clips).
+const POSTER_TIME_S = 1
+const POSTER_JPEG_QUALITY = 0.9
+
+/**
+ * Capture a poster frame of a video as a JPEG blob.
+ *
+ * @param {Blob} blob - the video bytes
+ * @param {number} timeoutMs - give up (resolve null) after this long
+ * @returns {Promise<Blob|null>} the JPEG poster, or null when capture failed
+ */
+export function captureVideoPoster(blob, timeoutMs = 30000) {
+    return new Promise(resolve => {
+        if (typeof URL.createObjectURL !== 'function') {
+            resolve(null)
+            return
+        }
+        const url = URL.createObjectURL(blob)
+        const video = document.createElement('video')
+        let done = false
+        const finish = poster => {
+            if (done) {
+                return
+            }
+            done = true
+            clearTimeout(timer)
+            // Detach the media before revoking its URL, so the decoder does
+            // not keep streaming from a dead object URL.
+            video.removeAttribute('src')
+            try {
+                video.load()
+            } catch (error) { /* already torn down */ }
+            URL.revokeObjectURL(url)
+            resolve(poster)
+        }
+        const timer = setTimeout(() => finish(null), timeoutMs)
+        const draw = () => {
+            const width = video.videoWidth
+            const height = video.videoHeight
+            const canvas = document.createElement('canvas')
+            const context = width > 0 && height > 0 ? canvas.getContext('2d') : null
+            if (context == null || typeof canvas.toBlob !== 'function') {
+                finish(null)
+                return
+            }
+            canvas.width = width
+            canvas.height = height
+            try {
+                context.drawImage(video, 0, 0, width, height)
+            } catch (error) {
+                finish(null)
+                return
+            }
+            canvas.toBlob(result => finish(result || null), 'image/jpeg', POSTER_JPEG_QUALITY)
+        }
+        video.muted = true
+        video.playsInline = true
+        video.preload = 'auto'
+        video.addEventListener('error', () => finish(null))
+        video.addEventListener('loadeddata', () => {
+            const target = Number.isFinite(video.duration)
+                ? Math.min(POSTER_TIME_S, video.duration / 2) : 0
+            if (target > video.currentTime) {
+                video.addEventListener('seeked', draw, { once: true })
+                try {
+                    video.currentTime = target
+                } catch (error) {
+                    draw()
+                }
+            } else {
+                draw()
+            }
+        }, { once: true })
+        video.src = url
+    })
+}


### PR DESCRIPTION
Closes #32.

## What

The web editor can now add videos to album pages, in the same way as images, producing the exact `VideoElement` format the Android app writes (video asset + generated poster thumbnail + the original file's name/size for asset reuse).

- The **"Add image"** toolbar button becomes **"Add media"**; its chooser lists videos alongside images (newest-first, play badge on video tiles, camera-icon fallback when the server cannot thumbnail a video).
- **Pick from server**: the video is linked into the album via `assetsearch` (a `.lnk`, no copy) — same as images.
- **Upload**: the bytes go up over `assetprobe` + native WebDAV — same as images and the Android app's `pushAsset`.
- In both cases a **poster frame** is captured browser-side (`src/utils/videoPoster.js`: off-DOM `<video>` + canvas, the web equivalent of Android's `ThumbnailUtils.createVideoThumbnail`) and uploaded as the element's `image` asset. Strictly best-effort: an undecodable codec or a failed upload saves the element with `image: ''`, which both the web viewer and Android tolerate.
- `name`/`size`/`mime` keep the original video's identity, so asset reuse (`assetsearch`/`clean`) matches the video, not the generated poster.

## Backend change (single one)

The SPA host page (`PageController::index`) now sets a CSP allowing `blob:` in `media-src`: Nextcloud's default policy blocked the object URL the poster capture plays the video from (found during end-to-end verification — without it, elements silently save without posters).

## Testing

- 16 new frontend tests (`buildVideoElement`, `VIDEO_MIMES`/`getFileBlob`, chooser video tiles & upload, poster failure paths); full suite: 216 passing, PHPUnit green.
- Verified end-to-end in a real browser against a local Nextcloud snap: both flows drove the deployed UI with a throwaway album — `album.json` held two correct `VideoElement`s, `data/` held the uploaded mp4, the picked video's `.lnk` and both poster JPEGs; the page displayed both videos playing with posters, and the videos survive round-tripping through the existing viewer.