### PR TITLE
Add multiple media at once from the web editor (#36)

### DIFF
--- a/src/components/ImageChooserDialog.vue
+++ b/src/components/ImageChooserDialog.vue
@@ -23,7 +23,7 @@
                 </NcButton>
                 <!-- Hidden native picker behind the upload button; `accept`
                      narrows the OS dialog to the mimetypes albums support. -->
-                <input ref="fileInput" type="file" class="chooser-file-input"
+                <input ref="fileInput" type="file" multiple class="chooser-file-input"
                     :accept="acceptMimes" v-on:change="onFileChosen" />
             </div>
 
@@ -46,10 +46,10 @@
                         </button>
                         <button v-else type="button"
                             class="chooser-tile chooser-image"
-                            :class="{ selected: selectedPath === entry.path }"
-                            :aria-pressed="String(selectedPath === entry.path)"
+                            :class="{ selected: isSelected(entry) }"
+                            :aria-pressed="String(isSelected(entry))"
                             :disabled="saving"
-                            v-on:click="select(entry)" v-on:dblclick="choose(entry)">
+                            v-on:click="select(entry)" v-on:dblclick="choose([entry])">
                             <img v-if="!failedPreviews[entry.path]" class="chooser-thumb"
                                 :src="previewUrl(entry)" :alt="entry.basename"
                                 loading="lazy"
@@ -59,6 +59,10 @@
                             <span v-if="isVideo(entry)" class="chooser-video-badge">
                                 <PlayCircleOutline :size="24" />
                             </span>
+                            <!-- Selection rank = the page order the media will be
+                                 inserted in (issue #36); only meaningful with 2+. -->
+                            <span v-if="selectedPaths.length > 1 && selectionOrder(entry) > 0"
+                                class="chooser-order-badge">{{ selectionOrder(entry) }}</span>
                             <span class="chooser-name">{{ entry.basename }}</span>
                         </button>
                     </li>
@@ -70,13 +74,13 @@
                 <NcButton :disabled="saving" v-on:click="$emit('close')">
                     {{ sCancel }}
                 </NcButton>
-                <NcButton variant="primary" :disabled="saving || selectedEntry == null"
-                    v-on:click="choose(selectedEntry)">
+                <NcButton variant="primary" :disabled="saving || selectedEntries.length === 0"
+                    v-on:click="choose(selectedEntries)">
                     <template #icon>
                         <NcLoadingIcon v-if="saving" :size="20" />
                         <Check v-else :size="20" />
                     </template>
-                    {{ sChoose }}
+                    {{ chooseLabel }}
                 </NcButton>
             </div>
         </div>
@@ -112,12 +116,14 @@ export default {
             "currentPath": "",
             "entries": [],
             "loading": false,
-            "selectedPath": null,
+            // Paths of the selected media, in click order — that order is the
+            // page order the album inserts them in (issue #36).
+            "selectedPaths": [],
             // Paths whose thumbnail failed to load (no preview provider):
             // their tiles fall back to a generic image icon.
             "failedPreviews": {},
             "acceptMimes": MEDIA_MIMES.join(','),
-            "sTitle": t("souvenirs", "Choose an image or a video"),
+            "sTitle": t("souvenirs", "Choose images or videos"),
             "sAllFiles": t("souvenirs", "All files"),
             "sUpload": t("souvenirs", "Upload"),
             "sCancel": t("souvenirs", "Cancel"),
@@ -152,8 +158,17 @@ export default {
             }
             return crumbs;
         },
-        'selectedEntry': function() {
-            return this.entries.find(e => e.path === this.selectedPath) || null;
+        'selectedEntries': function() {
+            // Selection order preserved; paths no longer listed are dropped.
+            return this.selectedPaths
+                .map(path => this.entries.find(e => e.path === path))
+                .filter(e => e != null);
+        },
+        'chooseLabel': function() {
+            const count = this.selectedEntries.length;
+            return count > 1
+                ? t("souvenirs", "Choose ({count})", { count: count })
+                : this.sChoose;
         },
     },
     mounted: function() {
@@ -172,7 +187,7 @@ export default {
         // (mounted() uses that for its root fallback).
         browse: async function(path) {
             this.loading = true;
-            this.selectedPath = null;
+            this.selectedPaths = [];
             var listed;
             try {
                 listed = await listFolder(path);
@@ -196,31 +211,45 @@ export default {
         isVideo: function(entry) {
             return VIDEO_MIMES.includes(entry.mime);
         },
-        select: function(entry) {
-            // Clicking the selected tile again deselects it.
-            this.selectedPath = this.selectedPath === entry.path ? null : entry.path;
+        isSelected: function(entry) {
+            return this.selectedPaths.includes(entry.path);
         },
-        choose: function(entry) {
-            if (this.saving || entry == null) {
+        selectionOrder: function(entry) {
+            // 1-based rank in the selection, 0 when not selected.
+            return this.selectedPaths.indexOf(entry.path) + 1;
+        },
+        select: function(entry) {
+            // Clicking a tile toggles it in/out of the selection (issue #36).
+            if (this.isSelected(entry)) {
+                this.selectedPaths = this.selectedPaths.filter(path => path !== entry.path);
+            } else {
+                this.selectedPaths = this.selectedPaths.concat(entry.path);
+            }
+        },
+        choose: function(entries) {
+            if (this.saving || entries.length === 0) {
                 return;
             }
-            this.$emit('pick', entry);
+            this.$emit('pick', entries);
         },
         previewUrl: function(entry) {
             return getPreviewUrl(entry.fileid);
         },
         onFileChosen: function(event) {
-            const file = event.target.files && event.target.files[0];
-            // Reset so picking the same file again re-fires `change`.
+            const files = Array.from(event.target.files || []);
+            // Reset so picking the same files again re-fires `change`.
             event.target.value = '';
-            if (!file) {
+            if (files.length === 0) {
                 return;
             }
-            if (!MEDIA_MIMES.includes(file.type)) {
+            const supported = files.filter(file => MEDIA_MIMES.includes(file.type));
+            if (supported.length < files.length) {
                 showError(t("souvenirs", "This file is not a supported image or video."));
+            }
+            if (supported.length === 0) {
                 return;
             }
-            this.$emit('upload', file);
+            this.$emit('upload', supported);
         },
     },
 }
@@ -295,6 +324,25 @@ let lastBrowsedPath = "";
     width: 100%;
     height: 100%;
     object-fit: cover;
+}
+/* Selection-order badge: the rank the media will be inserted in. Top-left,
+   clear of the video play badge (top-right). */
+.chooser-order-badge {
+    position: absolute;
+    top: 4px;
+    left: 4px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 24px;
+    height: 24px;
+    padding: 0 4px;
+    border-radius: 12px;
+    font-size: 13px;
+    font-weight: bold;
+    color: var(--color-primary-element-text, #ffffff);
+    background-color: var(--color-primary-element, #0082c9);
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.4);
 }
 /* Play badge marking video tiles apart from image ones. */
 .chooser-video-badge {

--- a/src/components/__tests__/ImageChooserDialog.test.js
+++ b/src/components/__tests__/ImageChooserDialog.test.js
@@ -81,7 +81,8 @@ describe('ImageChooserDialog', () => {
     it('emits pick with the video entry when a video is chosen', async () => {
         const wrapper = await mountDialog()
         await wrapper.findAll('.chooser-image')[1].trigger('dblclick')
-        expect(wrapper.emitted('pick')[0][0]).toMatchObject({ basename: 'clip.mp4', mime: 'video/mp4' })
+        expect(wrapper.emitted('pick')[0][0]).toHaveLength(1)
+        expect(wrapper.emitted('pick')[0][0][0]).toMatchObject({ basename: 'clip.mp4', mime: 'video/mp4' })
         wrapper.unmount()
     })
 
@@ -164,7 +165,51 @@ describe('ImageChooserDialog', () => {
         expect(chooseButton.attributes('disabled')).toBeUndefined()
         await chooseButton.trigger('click')
         expect(wrapper.emitted('pick')).toHaveLength(1)
-        expect(wrapper.emitted('pick')[0][0]).toMatchObject({ basename: 'new.png' })
+        expect(wrapper.emitted('pick')[0][0]).toHaveLength(1)
+        expect(wrapper.emitted('pick')[0][0][0]).toMatchObject({ basename: 'new.png' })
+        wrapper.unmount()
+    })
+
+    it('emits every selected entry in click order and counts them on the Choose button', async () => {
+        const wrapper = await mountDialog()
+        const tiles = wrapper.findAll('.chooser-image') // new.png, clip.mp4, old.jpg
+        await tiles[2].trigger('click')
+        await tiles[0].trigger('click')
+        // Both tiles selected, ranked in click order.
+        expect(tiles[2].attributes('aria-pressed')).toBe('true')
+        expect(tiles[0].attributes('aria-pressed')).toBe('true')
+        expect(tiles[2].find('.chooser-order-badge').text()).toBe('1')
+        expect(tiles[0].find('.chooser-order-badge').text()).toBe('2')
+        const chooseButton = wrapper.findAll('button').filter(b => b.text() === 'Choose (2)')[0]
+        expect(chooseButton).toBeDefined()
+        await chooseButton.trigger('click')
+        const picked = wrapper.emitted('pick')[0][0]
+        expect(picked.map(e => e.basename)).toEqual(['old.jpg', 'new.png'])
+        wrapper.unmount()
+    })
+
+    it('hides the order badge for a single selection', async () => {
+        const wrapper = await mountDialog()
+        const tile = wrapper.findAll('.chooser-image')[0]
+        await tile.trigger('click')
+        expect(tile.find('.chooser-order-badge').exists()).toBe(false)
+        wrapper.unmount()
+    })
+
+    it('clears the selection when navigating to another folder', async () => {
+        const wrapper = await mountDialog()
+        await wrapper.findAll('.chooser-image')[0].trigger('click')
+        await wrapper.findAll('.chooser-image')[1].trigger('click')
+        listFolder.mockResolvedValue([newImage])
+        await wrapper.find('.chooser-folder').trigger('click')
+        await flushBrowse()
+        expect(wrapper.find('.chooser-image').attributes('aria-pressed')).toBe('false')
+        const chooseButton = wrapper.findAll('button').filter(b => b.text() === 'Choose')[0]
+        expect(chooseButton.attributes('disabled')).toBeDefined()
+        // Back to the files root for the module-level folder memory.
+        listFolder.mockResolvedValue(ROOT_LISTING)
+        await wrapper.find('.crumb-stub').trigger('click')
+        await flushBrowse()
         wrapper.unmount()
     })
 
@@ -180,20 +225,21 @@ describe('ImageChooserDialog', () => {
     it('emits pick directly on double-click', async () => {
         const wrapper = await mountDialog()
         await wrapper.findAll('.chooser-image')[2].trigger('dblclick')
-        expect(wrapper.emitted('pick')[0][0]).toMatchObject({ basename: 'old.jpg' })
+        expect(wrapper.emitted('pick')[0][0][0]).toMatchObject({ basename: 'old.jpg' })
         wrapper.unmount()
     })
 
-    it('restricts the hidden input to media mimetypes and emits upload with the file', async () => {
+    it('restricts the hidden multi-file input to media mimetypes and emits upload with the files', async () => {
         const wrapper = await mountDialog()
         const input = wrapper.find('input[type=file]')
         expect(input.attributes('accept')).toContain('image/jpeg')
         expect(input.attributes('accept')).toContain('video/mp4')
+        expect(input.attributes('multiple')).toBeDefined()
         const file = new File(['bytes'], 'photo.jpg', { type: 'image/jpeg' })
         Object.defineProperty(input.element, 'files', { value: [file], configurable: true })
         await input.trigger('change')
         expect(wrapper.emitted('upload')).toHaveLength(1)
-        expect(wrapper.emitted('upload')[0][0]).toBe(file)
+        expect(wrapper.emitted('upload')[0][0]).toEqual([file])
         wrapper.unmount()
     })
 
@@ -203,7 +249,20 @@ describe('ImageChooserDialog', () => {
         const file = new File(['bytes'], 'clip.mp4', { type: 'video/mp4' })
         Object.defineProperty(input.element, 'files', { value: [file], configurable: true })
         await input.trigger('change')
-        expect(wrapper.emitted('upload')[0][0]).toBe(file)
+        expect(wrapper.emitted('upload')[0][0]).toEqual([file])
+        wrapper.unmount()
+    })
+
+    it('emits the supported files and toasts once when a multi-upload mixes in an unsupported one', async () => {
+        const wrapper = await mountDialog()
+        const input = wrapper.find('input[type=file]')
+        const photo = new File(['bytes'], 'photo.jpg', { type: 'image/jpeg' })
+        const doc = new File(['bytes'], 'doc.pdf', { type: 'application/pdf' })
+        const clip = new File(['bytes'], 'clip.mp4', { type: 'video/mp4' })
+        Object.defineProperty(input.element, 'files', { value: [photo, doc, clip], configurable: true })
+        await input.trigger('change')
+        expect(showError).toHaveBeenCalledTimes(1)
+        expect(wrapper.emitted('upload')[0][0]).toEqual([photo, clip])
         wrapper.unmount()
     })
 

--- a/src/components/album.vue
+++ b/src/components/album.vue
@@ -725,84 +725,137 @@ export default {
                 this.imageChooserPageId = null;
             }
         },
-        onImagePick: async function(entry) {
-            // The chooser offers images and videos (issue #32); a picked video
-            // goes through its own flow (VideoElement + poster capture).
-            if (VIDEO_MIMES.includes(entry.mime)) {
-                return this.onVideoPick(entry);
-            }
-            var index = this.pages.findIndex(p => p.id === this.imageChooserPageId);
-            if (index < 0 || this.imageChooserSaving) {
-                return;
-            }
+        onImagePick: function(entries) {
+            // The chooser emits the picked media as an array, in selection
+            // order (issue #36).
+            return this.addMediaItems(entries, this.prepareEntryElement);
+        },
+        onImageUpload: function(files) {
+            return this.addMediaItems(files, this.prepareFileElement);
+        },
+        prepareEntryElement: async function(entry) {
+            // Link a picked Nextcloud file into the album (no copy/upload) and
+            // return the element referencing it, or null after showing an
+            // error toast (the caller then keeps the chooser open). Videos get
+            // their poster captured too (issue #32), best-effort.
             const file = { name: entry.basename, size: entry.size, mime: entry.mime };
             if (!file.size) {
                 showError(t("souvenirs","Could not read the selected file."));
-                return;
+                return null;
             }
+            const isVideo = VIDEO_MIMES.includes(entry.mime);
             // Build the element first so we know the in-album asset path to link,
-            // then ask the backend to link the picked file to it (no copy/upload).
-            const element = buildImageElement(file);
-            this.imageChooserSaving = true;
-            var updatedPage;
+            // then ask the backend to link the picked file to it.
+            var element = isVideo ? buildVideoElement(file) : buildImageElement(file);
             try {
-                var res = await searchAsset(this.albumId, element.image, file.name, file.size);
+                var res = await searchAsset(this.albumId, isVideo ? element.video : element.image, file.name, file.size);
                 if (res == null || res.status !== "found") {
-                    // Keep the dialog open so the user can pick another file.
-                    this.imageChooserSaving = false;
-                    showError(t("souvenirs","Could not link the selected image. It must be located outside the Souvenirs albums folder."));
-                    return;
+                    showError(isVideo
+                        ? t("souvenirs","Could not link the selected video. It must be located outside the Souvenirs albums folder.")
+                        : t("souvenirs","Could not link the selected image. It must be located outside the Souvenirs albums folder."));
+                    return null;
                 }
-                updatedPage = addElement(this.pages[index], element);
-                await updatePage(this.albumId, updatedPage);
+                if (isVideo) {
+                    // The poster capture pulls the video bytes once over WebDAV;
+                    // no bytes just means no poster, the element stays usable.
+                    var blob = null;
+                    try {
+                        blob = await getFileBlob(entry.path);
+                    } catch (fetchError) {
+                    }
+                    element = (blob != null)
+                        ? await this.attachVideoPoster(element, blob)
+                        : { ...element, image: '' };
+                }
+                return element;
             } catch (error) {
-                this.imageChooserSaving = false;
-                showError(t("souvenirs","Could not add the image."));
-                return;
+                showError(isVideo ? t("souvenirs","Could not add the video.") : t("souvenirs","Could not add the image."));
+                // GC the link/poster of the never-persisted element.
+                cleanAssets(this.albumId).catch(() => {});
+                return null;
             }
-            this.pages.splice(index, 1, updatedPage);
-            this.imageChooserSaving = false;
-            this.imageChooserPageId = null;
         },
-        onImageUpload: async function(file) {
-            // Same split as onImagePick: uploaded videos have their own flow.
-            if (VIDEO_MIMES.includes(file.type)) {
-                return this.onVideoUpload(file);
-            }
-            var index = this.pages.findIndex(p => p.id === this.imageChooserPageId);
-            if (index < 0 || this.imageChooserSaving) {
-                return;
-            }
-            const element = buildImageElement({ name: file.name, size: file.size, mime: file.type });
-            this.imageChooserSaving = true;
-            var updatedPage;
+        prepareFileElement: async function(file) {
+            // Upload a local file as a new album asset and return the element
+            // referencing it, or null after showing an error toast. Same flow
+            // as the paint dialog (and the Android app): the probe returns
+            // where the asset lives under the user's files root, the bytes go
+            // up over native WebDAV, and the server must confirm the file
+            // landed before any page starts referencing it.
+            const isVideo = VIDEO_MIMES.includes(file.type);
+            var element = isVideo
+                ? buildVideoElement({ name: file.name, size: file.size, mime: file.type })
+                : buildImageElement({ name: file.name, size: file.size, mime: file.type });
+            const asset = isVideo ? element.video : element.image;
             try {
-                // Same upload flow as the paint dialog (and the Android app):
-                // the probe returns where the asset lives under the user's files
-                // root, the bytes go up over native WebDAV, and the server must
-                // confirm the file landed before the page starts referencing it.
-                var probe = await probeAsset(this.albumId, element.image);
+                var probe = await probeAsset(this.albumId, asset);
                 if (probe == null || !probe.path) {
                     throw new Error("assetprobe returned no upload path");
                 }
                 await uploadAsset(probe.path, file);
-                var check = await probeAsset(this.albumId, element.image);
+                var check = await probeAsset(this.albumId, asset);
                 if (check == null || check.status !== "ok") {
                     throw new Error("uploaded asset not found in the album");
                 }
-                updatedPage = addElement(this.pages[index], element);
-                await updatePage(this.albumId, updatedPage);
+                if (isVideo) {
+                    element = await this.attachVideoPoster(element, file);
+                }
+                return element;
             } catch (error) {
-                // Keep the dialog open so the user can retry; GC any bytes that
-                // landed before the failure (the element was never persisted).
-                this.imageChooserSaving = false;
-                showError(t("souvenirs","Could not upload the image."));
+                // GC any bytes that landed before the failure (the element was
+                // never persisted).
+                showError(isVideo ? t("souvenirs","Could not upload the video.") : t("souvenirs","Could not upload the image."));
                 cleanAssets(this.albumId).catch(() => {});
+                return null;
+            }
+        },
+        addMediaItems: async function(items, prepare) {
+            // Insert the chosen media in order (issue #36): the first one joins
+            // the page the chooser was opened from (as a single pick always
+            // did), each further one gets its own new page right after — one
+            // medium per page.
+            var that = this;
+            var targetIndex = this.pages.findIndex(p => p.id === this.imageChooserPageId);
+            if (targetIndex < 0 || this.imageChooserSaving || items.length === 0) {
                 return;
             }
-            this.pages.splice(index, 1, updatedPage);
+            this.imageChooserSaving = true;
+            var inserted = 0;
+            for (const item of items) {
+                var element = await prepare(item);
+                if (element == null) {
+                    // Error already shown; keep the dialog open (media inserted
+                    // so far stay) so the user can retry or pick something else.
+                    this.imageChooserSaving = false;
+                    return;
+                }
+                try {
+                    if (inserted === 0) {
+                        var updatedPage = addElement(this.pages[targetIndex], element);
+                        await updatePage(this.albumId, updatedPage);
+                        this.pages.splice(targetIndex, 1, updatedPage);
+                    } else {
+                        var pos = targetIndex + inserted;
+                        var page = addElement(buildPage(), element);
+                        await createPage(this.albumId, pos, page);
+                        this.pages.splice(pos, 0, page);
+                    }
+                } catch (error) {
+                    this.imageChooserSaving = false;
+                    showError(element.class === "VideoElement"
+                        ? t("souvenirs","Could not add the video.")
+                        : t("souvenirs","Could not add the image."));
+                    cleanAssets(this.albumId).catch(() => {});
+                    return;
+                }
+                inserted++;
+            }
             this.imageChooserSaving = false;
             this.imageChooserPageId = null;
+            if (inserted > 1) {
+                // Land on the last created page so the whole batch is visible.
+                this.$nextTick(() => { that.showN(targetIndex + inserted - 1); });
+            }
         },
         attachVideoPoster: async function(element, videoBlob) {
             // Capture a poster frame of the video and upload it as the
@@ -828,88 +881,6 @@ export default {
             } catch (error) {
                 return { ...element, image: '' };
             }
-        },
-        onVideoPick: async function(entry) {
-            var index = this.pages.findIndex(p => p.id === this.imageChooserPageId);
-            if (index < 0 || this.imageChooserSaving) {
-                return;
-            }
-            const file = { name: entry.basename, size: entry.size, mime: entry.mime };
-            if (!file.size) {
-                showError(t("souvenirs","Could not read the selected file."));
-                return;
-            }
-            // Same shape as onImagePick — link the picked file to the element's
-            // video asset (no copy/upload) — plus the poster capture, for which
-            // the video bytes are pulled once over WebDAV.
-            var element = buildVideoElement(file);
-            this.imageChooserSaving = true;
-            var updatedPage;
-            try {
-                var res = await searchAsset(this.albumId, element.video, file.name, file.size);
-                if (res == null || res.status !== "found") {
-                    // Keep the dialog open so the user can pick another file.
-                    this.imageChooserSaving = false;
-                    showError(t("souvenirs","Could not link the selected video. It must be located outside the Souvenirs albums folder."));
-                    return;
-                }
-                var blob = null;
-                try {
-                    blob = await getFileBlob(entry.path);
-                } catch (fetchError) {
-                    // No bytes, no poster: the element is still fully usable.
-                }
-                element = (blob != null)
-                    ? await this.attachVideoPoster(element, blob)
-                    : { ...element, image: '' };
-                updatedPage = addElement(this.pages[index], element);
-                await updatePage(this.albumId, updatedPage);
-            } catch (error) {
-                this.imageChooserSaving = false;
-                showError(t("souvenirs","Could not add the video."));
-                // GC the link/poster of the never-persisted element.
-                cleanAssets(this.albumId).catch(() => {});
-                return;
-            }
-            this.pages.splice(index, 1, updatedPage);
-            this.imageChooserSaving = false;
-            this.imageChooserPageId = null;
-        },
-        onVideoUpload: async function(file) {
-            var index = this.pages.findIndex(p => p.id === this.imageChooserPageId);
-            if (index < 0 || this.imageChooserSaving) {
-                return;
-            }
-            var element = buildVideoElement({ name: file.name, size: file.size, mime: file.type });
-            this.imageChooserSaving = true;
-            var updatedPage;
-            try {
-                // Same upload flow as images (and the Android app): probe for
-                // the WebDAV destination, upload the bytes, and have the server
-                // confirm the video landed before the page references it.
-                var probe = await probeAsset(this.albumId, element.video);
-                if (probe == null || !probe.path) {
-                    throw new Error("assetprobe returned no upload path");
-                }
-                await uploadAsset(probe.path, file);
-                var check = await probeAsset(this.albumId, element.video);
-                if (check == null || check.status !== "ok") {
-                    throw new Error("uploaded asset not found in the album");
-                }
-                element = await this.attachVideoPoster(element, file);
-                updatedPage = addElement(this.pages[index], element);
-                await updatePage(this.albumId, updatedPage);
-            } catch (error) {
-                // Keep the dialog open so the user can retry; GC any bytes that
-                // landed before the failure (the element was never persisted).
-                this.imageChooserSaving = false;
-                showError(t("souvenirs","Could not upload the video."));
-                cleanAssets(this.albumId).catch(() => {});
-                return;
-            }
-            this.pages.splice(index, 1, updatedPage);
-            this.imageChooserSaving = false;
-            this.imageChooserPageId = null;
         },
         resizeEventHandler: function(e) {
             if (window.innerHeight > window.innerWidth) {

--- a/tests/frontend/setup.js
+++ b/tests/frontend/setup.js
@@ -4,6 +4,9 @@
 // CSRF token used by the API layer (albumApi.js).
 globalThis.OC = globalThis.OC || { requestToken: 'test-token' }
 
-// Translation helper used throughout the components; pass text through verbatim.
-globalThis.t = globalThis.t || ((app, text) => text)
+// Translation helper used throughout the components; pass text through
+// verbatim, substituting {placeholders} like the real helper does.
+globalThis.t = globalThis.t || ((app, text, vars) => (
+    vars ? text.replace(/{([^{}]+)}/g, (match, key) => (key in vars ? String(vars[key]) : match)) : text
+))
 globalThis.n = globalThis.n || ((app, singular, plural, count) => (count === 1 ? singular : plural))


### PR DESCRIPTION
Closes #36.

## What this does

- **Media chooser multi-selection** (`ImageChooserDialog.vue`): clicking tiles toggles them in/out of a selection; the click order is preserved and shown as a numbered badge on each selected tile. The Choose button shows the count ("Choose (3)") and emits all selected entries; double-click stays a one-item fast path. The hidden upload input now accepts multiple files (unsupported ones are dropped with the existing toast, supported ones proceed). Both `pick` and `upload` events now carry arrays.
- **One medium per page** (`album.vue`): the batch is inserted sequentially — the first item joins the page the chooser was opened from (identical to a single pick today), each further item gets its own new page inserted right after, in selection order, and the view lands on the last created page. On a mid-batch failure the dialog stays open with the existing error toast and already-inserted media are kept.
- **Refactor**: the four near-duplicate handlers (image/video × pick/upload) are folded into two per-item prepare helpers (`prepareEntryElement`, `prepareFileElement`) plus one orchestrator (`addMediaItems`), reusing the existing link (assetsearch), upload (assetprobe + WebDAV PUT + confirm) and video-poster flows unchanged.

## Tests / verification

- Chooser vitest suite updated for array payloads, plus new cases: click-order emission, counting Choose label, badge visibility, selection reset on folder navigation, mixed valid/invalid multi-upload. All 220 frontend tests pass; `setup.js`'s `t()` stub now substitutes `{placeholders}`.
- Verified end-to-end with Playwright against a deployed instance: picking 3 images produced 3 pages with one image each in click order; a 2-file upload on a 1-element page made the first file join that page and the second get its own new page.