### PR TITLE
Add share expiration (#24)

### DIFF
--- a/lib/Controller/Api2Controller.php
+++ b/lib/Controller/Api2Controller.php
@@ -424,13 +424,23 @@ class Api2Controller extends ApiController {
 	 * @NoAdminRequired
 	 * @NoCSRFRequired
 	 */
-	public function createShare($albumId) {
+	public function createShare($albumId, $validUntil = null) {
 		//make sure the album actually exists for this user before sharing it
 		$album_db = $this->albumMapper->findByAlbumId($this->userId, $albumId);
 		if (is_null($album_db)) {
 			return new JSONResponse(array(), Http::STATUS_NOT_FOUND);
 		}
-		$results = $this->shareMapper->createShare($this->userId,$albumId);
+		//optional expiration date (YYYY-MM-DD); the share stays valid through that day.
+		//null falls back to the mapper default (+3 months) so older clients keep working.
+		$validUntilDate = null;
+		if (!is_null($validUntil) && $validUntil !== '') {
+			$validUntilDate = \DateTime::createFromFormat('Y-m-d', $validUntil);
+			if ($validUntilDate === false) {
+				return new JSONResponse(array(), Http::STATUS_BAD_REQUEST);
+			}
+			$validUntilDate->setTime(23, 59, 59);
+		}
+		$results = $this->shareMapper->createShare($this->userId, $albumId, $validUntilDate);
 		//get shareUrl
 		$shareUrl = $this->urlGen->linkToRouteAbsolute('souvenirs.public.show',array('token' => $results['share']['token']));
 

--- a/lib/Controller/PublicController.php
+++ b/lib/Controller/PublicController.php
@@ -3,6 +3,7 @@ namespace OCA\Souvenirs\Controller;
 
 use OCP\IRequest;
 use OCP\IConfig;
+use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\Http\Template\PublicTemplateResponse;

--- a/lib/Cron/DbUpdate.php
+++ b/lib/Cron/DbUpdate.php
@@ -9,6 +9,7 @@ use OCP\Files\IRootFolder;
 use OCA\Souvenirs\Controller\Utils;
 use OCA\Souvenirs\Model\AlbumList;
 use OCA\Souvenirs\Db\AlbumMapper;
+use OCA\Souvenirs\Db\ShareMapper;
 use OCP\IConfig;
 
 class DbUpdate extends TimedJob {
@@ -16,8 +17,9 @@ class DbUpdate extends TimedJob {
     private IUserManager $userManager;
     private IRootFolder $rootFolder;
     private AlbumMapper $albumMapper;
+    private ShareMapper $shareMapper;
 
-    public function __construct(ITimeFactory $time, IUserManager $userManager, IRootFolder $rootFolder, IConfig $config, AlbumMapper $albumMapper) {
+    public function __construct(ITimeFactory $time, IUserManager $userManager, IRootFolder $rootFolder, IConfig $config, AlbumMapper $albumMapper, ShareMapper $shareMapper) {
         parent::__construct($time);
 
         // Run once a day
@@ -27,9 +29,13 @@ class DbUpdate extends TimedJob {
         $this->rootFolder = $rootFolder;
         $this->config = $config;
         $this->albumMapper = $albumMapper;
+        $this->shareMapper = $shareMapper;
     }
 
     protected function run($arguments) {
+
+        //remove expired shares (shares with no expiration date are kept)
+        $this->shareMapper->deleteExpired($this->time->getDateTime());
 
         //for all users
         $this->userManager->callForSeenUsers(function (IUser $user): void {

--- a/lib/Db/Share.php
+++ b/lib/Db/Share.php
@@ -4,6 +4,7 @@
 namespace OCA\Souvenirs\Db;
 
 use OCP\AppFramework\Db\Entity;
+use OCP\DB\Types;
 
 class Share extends Entity {
 
@@ -12,8 +13,17 @@ class Share extends Entity {
     protected $user;
     protected $albumId;
 
+    public function __construct() {
+        $this->addType('validUntil', Types::DATETIME);
+    }
+
     public function toArray() {
-        return array('token' => $this->token, 'albumId' => $this->albumId, 'validUntil' => $this->validUntil, 'user' => $this->user);
+        return array(
+            'token' => $this->token,
+            'albumId' => $this->albumId,
+            'validUntil' => is_null($this->validUntil) ? null : $this->validUntil->format(\DateTime::ATOM),
+            'user' => $this->user,
+        );
     }
 
 }

--- a/lib/Db/ShareMapper.php
+++ b/lib/Db/ShareMapper.php
@@ -73,7 +73,7 @@ class ShareMapper extends QBMapper {
         } 
     }
 
-    public function createShare(string $user, string $albumId) {
+    public function createShare(string $user, string $albumId, ?\DateTime $validUntil = null) {
 
         //check if share exists
         $res = $this->findByAlbumId($user,$albumId);
@@ -87,8 +87,25 @@ class ShareMapper extends QBMapper {
         $newShare->setToken($newToken);
         $newShare->setUser($user);
         $newShare->setAlbumId($albumId);
+        $newShare->setValidUntil($validUntil ?? new \DateTime('+3 months'));
         $this->insert($newShare);
         return array('action' => 'success', 'share' => $newShare->toArray());
+    }
+
+    /**
+     * Delete every share whose expiration date has passed.
+     * Shares with a NULL valid_until never expire.
+     */
+    public function deleteExpired(\DateTime $now): void {
+        $qb = $this->db->getQueryBuilder();
+        $qb->delete(SHARE_TABLE)
+            ->where(
+                $qb->expr()->andX(
+                    $qb->expr()->isNotNull('valid_until'),
+                    $qb->expr()->lt('valid_until', $qb->createNamedParameter($now, IQueryBuilder::PARAM_DATETIME_MUTABLE))
+                )
+            );
+        $qb->executeStatement();
     }
 
     public function deleteShare(string $user, string $albumId) {

--- a/src/components/album-item.vue
+++ b/src/components/album-item.vue
@@ -16,8 +16,10 @@
     </router-link>
     <div v-bind:class="[ 'right', isWinPortrait ? 's-action-menu-portrait': 's-action-menu' ]">
         <NcActions default-icon="icon-shared" :force-menu="true" v-bind:style='(isShared) ? "opacity: 1" : "opacity: 0.3"'>
+            <NcActionInput type="date" :is-native-picker="true" :label="sExpiresOn" v-model="shareExpiry" v-if="!(isShared)">{{sExpiresOn}}</NcActionInput>
             <NcActionButton icon="icon-shared" @click="toggleShare" v-if="!(isShared)">Share album</NcActionButton>
             <NcActionLink icon="icon-external" v-bind:href="shareUrl" target="_blank" v-if="isShared" v-on:click="copyShareUrlToClipboard">Link to public album</NcActionLink>
+            <NcActionText icon="icon-calendar-dark" v-if="isShared && shareExpiryString != ''">{{sExpiresOn}} {{shareExpiryString}}</NcActionText>
             <NcActionButton icon="icon-delete" @click="toggleShare" v-if="isShared" :close-after-click="true">Remove share</NcActionButton>
         </NcActions>
         <NcButton variant="tertiary" :aria-label="sEditAlbum" :title="sEditAlbum" v-on:click="onEditInfo">
@@ -37,9 +39,10 @@
 
 <script>
 
-import { NcActionLink, NcActionButton, NcActions, NcButton } from '@nextcloud/vue'
+import { NcActionLink, NcActionButton, NcActionInput, NcActionText, NcActions, NcButton } from '@nextcloud/vue'
 import { generateUrl, imagePath } from '@nextcloud/router'
 import Pencil from 'vue-material-design-icons/Pencil.vue'
+import { defaultExpiryDate, toApiDate } from '../utils/shareExpiry.js'
 
 export default {
     props: {
@@ -54,12 +57,16 @@ export default {
     data: function() {
         return {
             "sEditAlbum": t("souvenirs","Edit album"),
+            "sExpiresOn": t("souvenirs","Expires on"),
+            "shareExpiry": defaultExpiryDate(),
         }
     },
     components: {
         NcActions,
         NcActionButton,
+        NcActionInput,
         NcActionLink,
+        NcActionText,
         NcButton,
         Pencil,
     },
@@ -78,6 +85,18 @@ export default {
                 return this.shares.find(share => {
                     return share['albumId'] == this.albumId
                 }).token;
+            }
+            return "";
+        },
+        "shareExpiryString": function() {
+            if (this.isShared) {
+                const validUntil = this.shares.find(share => {
+                    return share['albumId'] == this.albumId
+                }).validUntil;
+                if (validUntil) {
+                    moment.locale(window.navigator.language);
+                    return moment(validUntil).format("LL");
+                }
             }
             return "";
         },
@@ -153,7 +172,11 @@ export default {
                         'Content-Type': 'application/json'
                     },
                     method: "POST",
-                    body: JSON.stringify({'albumId': this.albumId})
+                    body: JSON.stringify({
+                        'albumId': this.albumId,
+                        //null lets the server apply its default expiration
+                        'validUntil': this.shareExpiry ? toApiDate(this.shareExpiry) : null,
+                    })
                     })
                 .then(response => {
                     that.$emit('refresh-shares');

--- a/src/utils/__tests__/shareExpiry.test.js
+++ b/src/utils/__tests__/shareExpiry.test.js
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest'
+import { defaultExpiryDate, toApiDate } from '../shareExpiry.js'
+
+describe('defaultExpiryDate', () => {
+    it('returns a date 3 months ahead', () => {
+        const d = defaultExpiryDate(new Date(2026, 0, 15)) // Jan 15 2026
+        expect(d.getFullYear()).toBe(2026)
+        expect(d.getMonth()).toBe(3) // April
+        expect(d.getDate()).toBe(15)
+    })
+
+    it('rolls over the year boundary', () => {
+        const d = defaultExpiryDate(new Date(2026, 10, 5)) // Nov 5 2026
+        expect(d.getFullYear()).toBe(2027)
+        expect(d.getMonth()).toBe(1) // February
+        expect(d.getDate()).toBe(5)
+    })
+
+    it('clamps to the last day of the target month instead of overflowing', () => {
+        const d = defaultExpiryDate(new Date(2026, 10, 30)) // Nov 30 2026 -> Feb 2027 (28 days)
+        expect(d.getFullYear()).toBe(2027)
+        expect(d.getMonth()).toBe(1) // February, not March
+        expect(d.getDate()).toBe(28)
+    })
+
+    it('clamps to Feb 29 on leap years', () => {
+        const d = defaultExpiryDate(new Date(2027, 10, 30)) // Nov 30 2027 -> Feb 2028 (leap)
+        expect(d.getFullYear()).toBe(2028)
+        expect(d.getMonth()).toBe(1)
+        expect(d.getDate()).toBe(29)
+    })
+})
+
+describe('toApiDate', () => {
+    it('formats as YYYY-MM-DD with zero padding', () => {
+        expect(toApiDate(new Date(2026, 3, 5))).toBe('2026-04-05')
+        expect(toApiDate(new Date(2026, 11, 25))).toBe('2026-12-25')
+    })
+})

--- a/src/utils/shareExpiry.js
+++ b/src/utils/shareExpiry.js
@@ -1,0 +1,26 @@
+/**
+ * Default share expiration: 3 months from the given date.
+ * Clamps to the last day of the target month when the day would
+ * overflow (e.g. Nov 30 + 3 months -> Feb 28/29, not Mar 2).
+ *
+ * @param {Date} from reference date (defaults to now)
+ * @return {Date}
+ */
+export function defaultExpiryDate(from = new Date()) {
+    const d = new Date(from.getFullYear(), from.getMonth() + 3, from.getDate())
+    if (d.getDate() !== from.getDate()) {
+        d.setDate(0)
+    }
+    return d
+}
+
+/**
+ * Format a date as the YYYY-MM-DD string expected by the share API.
+ *
+ * @param {Date} date
+ * @return {string}
+ */
+export function toApiDate(date) {
+    const pad = (n) => String(n).padStart(2, '0')
+    return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`
+}

--- a/tests/Unit/Db/ShareTest.php
+++ b/tests/Unit/Db/ShareTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace OCA\Souvenirs\Tests\Unit\Db;
+
+use OCA\Souvenirs\Db\Share;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Pins the JSON shape of a share as consumed by the web SPA and the Android
+ * client: validUntil must serialize as an ISO-8601 string, and NULL (legacy
+ * never-expiring shares) must pass through unchanged.
+ */
+class ShareTest extends TestCase {
+
+    public function testToArrayFormatsValidUntil(): void {
+        $share = new Share();
+        $share->setToken('tok123');
+        $share->setUser('alice');
+        $share->setAlbumId('album-1');
+        $share->setValidUntil(new \DateTime('2026-10-21 23:59:59', new \DateTimeZone('UTC')));
+
+        $array = $share->toArray();
+        $this->assertSame('tok123', $array['token']);
+        $this->assertSame('alice', $array['user']);
+        $this->assertSame('album-1', $array['albumId']);
+        $this->assertSame('2026-10-21T23:59:59+00:00', $array['validUntil']);
+    }
+
+    public function testToArrayKeepsNullValidUntil(): void {
+        $share = new Share();
+        $share->setToken('tok123');
+        $share->setUser('alice');
+        $share->setAlbumId('album-1');
+
+        $this->assertNull($share->toArray()['validUntil']);
+    }
+
+    public function testSetterAcceptsDateStringViaDeclaredType(): void {
+        // Entity converts strings to \DateTime for Types::DATETIME fields —
+        // this is what hydration from the DB row relies on.
+        $share = new Share();
+        $share->setValidUntil('2026-10-21 12:00:00');
+        $this->assertInstanceOf(\DateTime::class, $share->getValidUntil());
+    }
+}


### PR DESCRIPTION
Closes #24.

## What

- **DB**: the `valid_until` column already existed in `souvenirs_shares` (nullable, unused) — no migration needed. `Share` entity now declares it as a datetime field and serializes it as ISO-8601 in `toArray()`.
- **Creation**: `ShareMapper::createShare()` sets `valid_until` on new shares, defaulting to now + 3 months. `POST /apiv2/share` accepts an optional `validUntil` (`YYYY-MM-DD`); the share stays valid through 23:59:59 of that day, and an unparseable value returns 400.
- **Cleanup**: the daily `DbUpdate` cron job deletes shares whose `valid_until` has passed. Since all public endpoints resolve the token via `findByToken()`, deleting the row is enough to kill the public URL (at most ~24h after the expiry date).
- **Web UI**: the album share menu now shows a native date picker ("Expires on") pre-filled with +3 months next to "Share album", sends `validUntil` with the creation request, and displays the expiry date on already-shared albums.

## Compatibility

- Existing shares (`valid_until` NULL) never expire — the cron only deletes rows with a non-NULL date in the past.
- The Android client is unaffected: `validUntil` is optional and the response shape of `create_share` is unchanged; shares it creates get the server-side 3-month default.

## Tests

- `tests/Unit/Db/ShareTest.php`: `toArray()` ISO formatting, NULL passthrough, string→DateTime hydration.
- `src/utils/__tests__/shareExpiry.test.js`: +3-month default incl. month-end clamping and leap years, API date formatting.
- Full suites pass: `make test` (11 PHP tests, 225 JS tests).