### PR TITLE
Add audio to album pages from the web editor (#33)

### DIFF
--- a/src/api/davApi.js
+++ b/src/api/davApi.js
@@ -41,6 +41,26 @@ export const VIDEO_MIMES = [
 ]
 
 /**
+ * The audio mimetypes an album page can play (issue #33): what HTML5
+ * `Audio` commonly decodes and the Android app records/picks. Both the
+ * PROPFIND spelling and the browser `File.type` spelling are listed where
+ * they differ (wav, m4a). Shared by the chooser's grid filter and its
+ * upload input's `accept` attribute, like IMAGE_MIMES.
+ */
+export const AUDIO_MIMES = [
+    'audio/mpeg',
+    'audio/mp4',
+    'audio/x-m4a',
+    'audio/aac',
+    'audio/ogg',
+    'audio/opus',
+    'audio/wav',
+    'audio/x-wav',
+    'audio/flac',
+    'audio/webm',
+]
+
+/**
  * Encode a user-files-relative path for use in a WebDAV URL: per-segment
  * percent-encoding, empty segments dropped so the URL never contains a double
  * slash (same rules as albumApi.js uploadAsset).

--- a/src/components/ImageChooserDialog.vue
+++ b/src/components/ImageChooserDialog.vue
@@ -55,9 +55,15 @@
                                 loading="lazy"
                                 v-on:error="failedPreviews[entry.path] = true" />
                             <VideoIcon v-else-if="isVideo(entry)" :size="48" />
+                            <MusicNote v-else-if="isAudio(entry)" :size="48" />
                             <ImageIcon v-else :size="48" />
                             <span v-if="isVideo(entry)" class="chooser-video-badge">
                                 <PlayCircleOutline :size="24" />
+                            </span>
+                            <!-- Audio badge: keeps audio tiles apart even when
+                                 the preview loads (MP3 embedded cover art). -->
+                            <span v-if="isAudio(entry)" class="chooser-audio-badge">
+                                <MusicNote :size="24" />
                             </span>
                             <!-- Selection rank = the page order the media will be
                                  inserted in (issue #36); only meaningful with 2+. -->
@@ -95,13 +101,15 @@ import Folder from 'vue-material-design-icons/Folder.vue'
 import UploadIcon from 'vue-material-design-icons/Upload.vue'
 import ImageIcon from 'vue-material-design-icons/Image.vue'
 import VideoIcon from 'vue-material-design-icons/Video.vue'
+import MusicNote from 'vue-material-design-icons/MusicNote.vue'
 import PlayCircleOutline from 'vue-material-design-icons/PlayCircleOutline.vue'
 import Check from 'vue-material-design-icons/Check.vue'
 import { showError } from '@nextcloud/dialogs'
-import { listFolder, getPreviewUrl, IMAGE_MIMES, VIDEO_MIMES } from '../api/davApi.js'
+import { listFolder, getPreviewUrl, IMAGE_MIMES, VIDEO_MIMES, AUDIO_MIMES } from '../api/davApi.js'
 
-// Everything the chooser offers: images and, since issue #32, videos.
-const MEDIA_MIMES = IMAGE_MIMES.concat(VIDEO_MIMES)
+// Everything the chooser offers: images, videos (issue #32) and, since
+// issue #33, audio tracks.
+const MEDIA_MIMES = IMAGE_MIMES.concat(VIDEO_MIMES).concat(AUDIO_MIMES)
 
 export default {
     props: {
@@ -123,12 +131,12 @@ export default {
             // their tiles fall back to a generic image icon.
             "failedPreviews": {},
             "acceptMimes": MEDIA_MIMES.join(','),
-            "sTitle": t("souvenirs", "Choose images or videos"),
+            "sTitle": t("souvenirs", "Choose media"),
             "sAllFiles": t("souvenirs", "All files"),
             "sUpload": t("souvenirs", "Upload"),
             "sCancel": t("souvenirs", "Cancel"),
             "sChoose": t("souvenirs", "Choose"),
-            "sEmpty": t("souvenirs", "No images or videos in this folder."),
+            "sEmpty": t("souvenirs", "No media in this folder."),
         }
     },
     components: {
@@ -143,6 +151,7 @@ export default {
         UploadIcon,
         ImageIcon,
         VideoIcon,
+        MusicNote,
         PlayCircleOutline,
         Check,
     },
@@ -211,6 +220,9 @@ export default {
         isVideo: function(entry) {
             return VIDEO_MIMES.includes(entry.mime);
         },
+        isAudio: function(entry) {
+            return AUDIO_MIMES.includes(entry.mime);
+        },
         isSelected: function(entry) {
             return this.selectedPaths.includes(entry.path);
         },
@@ -244,7 +256,7 @@ export default {
             }
             const supported = files.filter(file => MEDIA_MIMES.includes(file.type));
             if (supported.length < files.length) {
-                showError(t("souvenirs", "This file is not a supported image or video."));
+                showError(t("souvenirs", "This file is not a supported image, video or audio file."));
             }
             if (supported.length === 0) {
                 return;
@@ -344,8 +356,9 @@ let lastBrowsedPath = "";
     background-color: var(--color-primary-element, #0082c9);
     box-shadow: 0 1px 2px rgba(0, 0, 0, 0.4);
 }
-/* Play badge marking video tiles apart from image ones. */
-.chooser-video-badge {
+/* Play/music badges marking video and audio tiles apart from image ones. */
+.chooser-video-badge,
+.chooser-audio-badge {
     position: absolute;
     top: 4px;
     right: 4px;

--- a/src/components/__tests__/ImageChooserDialog.test.js
+++ b/src/components/__tests__/ImageChooserDialog.test.js
@@ -5,6 +5,7 @@ vi.mock('@nextcloud/dialogs', () => ({ showError: vi.fn() }))
 vi.mock('../../api/davApi.js', () => ({
     IMAGE_MIMES: ['image/png', 'image/jpeg', 'image/gif', 'image/webp', 'image/bmp', 'image/tiff', 'image/svg+xml'],
     VIDEO_MIMES: ['video/mp4', 'video/webm', 'video/ogg', 'video/quicktime', 'video/x-matroska'],
+    AUDIO_MIMES: ['audio/mpeg', 'audio/mp4', 'audio/x-m4a', 'audio/aac', 'audio/ogg', 'audio/opus', 'audio/wav', 'audio/x-wav', 'audio/flac', 'audio/webm'],
     listFolder: vi.fn(),
     getPreviewUrl: vi.fn(fileid => 'preview-' + fileid),
 }))
@@ -24,8 +25,9 @@ const oldImage = { basename: 'old.jpg', path: 'old.jpg', isFolder: false, mime: 
 const newImage = { basename: 'new.png', path: 'new.png', isFolder: false, mime: 'image/png', size: 20, mtime: 2000, fileid: '11' }
 const notImage = { basename: 'doc.pdf', path: 'doc.pdf', isFolder: false, mime: 'application/pdf', size: 30, mtime: 3000, fileid: '12' }
 const video = { basename: 'clip.mp4', path: 'clip.mp4', isFolder: false, mime: 'video/mp4', size: 40, mtime: 1500, fileid: '13' }
+const audio = { basename: 'song.mp3', path: 'song.mp3', isFolder: false, mime: 'audio/mpeg', size: 50, mtime: 900, fileid: '14' }
 
-const ROOT_LISTING = [oldImage, folderB, notImage, newImage, folderA, video]
+const ROOT_LISTING = [oldImage, folderB, notImage, newImage, folderA, video, audio]
 
 async function mountDialog(props = {}) {
     listFolder.mockReset()
@@ -58,13 +60,13 @@ describe('ImageChooserDialog', () => {
         // by mounting once and navigating home via the root crumb when needed.
     })
 
-    it('lists folders first (alphabetical), then images and videos newest-first, other mimes dropped', async () => {
+    it('lists folders first (alphabetical), then media newest-first, other mimes dropped', async () => {
         const wrapper = await mountDialog()
         // Make the memory-dependent start deterministic: go to the root crumb.
         await wrapper.find('.crumb-stub').trigger('click')
         await flushBrowse()
         const names = wrapper.findAll('.chooser-name').map(n => n.text())
-        expect(names).toEqual(['A-folder', 'b-folder', 'new.png', 'clip.mp4', 'old.jpg'])
+        expect(names).toEqual(['A-folder', 'b-folder', 'new.png', 'clip.mp4', 'old.jpg', 'song.mp3'])
         expect(names).not.toContain('doc.pdf')
         wrapper.unmount()
     })
@@ -72,9 +74,36 @@ describe('ImageChooserDialog', () => {
     it('marks video tiles with a play badge, image tiles without', async () => {
         const wrapper = await mountDialog()
         const tiles = wrapper.findAll('.chooser-image')
-        // newest-first: new.png, clip.mp4, old.jpg
+        // newest-first: new.png, clip.mp4, old.jpg, song.mp3
         expect(tiles[1].find('.chooser-video-badge').exists()).toBe(true)
         expect(tiles[0].find('.chooser-video-badge').exists()).toBe(false)
+        wrapper.unmount()
+    })
+
+    it('marks audio tiles with a music badge, other tiles without', async () => {
+        const wrapper = await mountDialog()
+        const tiles = wrapper.findAll('.chooser-image')
+        expect(tiles[3].find('.chooser-audio-badge').exists()).toBe(true)
+        expect(tiles[0].find('.chooser-audio-badge').exists()).toBe(false)
+        expect(tiles[1].find('.chooser-audio-badge').exists()).toBe(false)
+        wrapper.unmount()
+    })
+
+    it('emits pick with the audio entry when an audio file is chosen', async () => {
+        const wrapper = await mountDialog()
+        await wrapper.findAll('.chooser-image')[3].trigger('dblclick')
+        expect(wrapper.emitted('pick')[0][0]).toHaveLength(1)
+        expect(wrapper.emitted('pick')[0][0][0]).toMatchObject({ basename: 'song.mp3', mime: 'audio/mpeg' })
+        wrapper.unmount()
+    })
+
+    it('swaps a broken audio thumbnail for the music-note icon', async () => {
+        const wrapper = await mountDialog()
+        const tile = wrapper.findAll('.chooser-image')[3]
+        await tile.find('.chooser-thumb').trigger('error')
+        expect(tile.find('.chooser-thumb').exists()).toBe(false)
+        // Fallback icon plus the always-on badge.
+        expect(tile.findAll('.music-note-icon').length).toBe(2)
         wrapper.unmount()
     })
 
@@ -234,6 +263,7 @@ describe('ImageChooserDialog', () => {
         const input = wrapper.find('input[type=file]')
         expect(input.attributes('accept')).toContain('image/jpeg')
         expect(input.attributes('accept')).toContain('video/mp4')
+        expect(input.attributes('accept')).toContain('audio/mpeg')
         expect(input.attributes('multiple')).toBeDefined()
         const file = new File(['bytes'], 'photo.jpg', { type: 'image/jpeg' })
         Object.defineProperty(input.element, 'files', { value: [file], configurable: true })
@@ -247,6 +277,16 @@ describe('ImageChooserDialog', () => {
         const wrapper = await mountDialog()
         const input = wrapper.find('input[type=file]')
         const file = new File(['bytes'], 'clip.mp4', { type: 'video/mp4' })
+        Object.defineProperty(input.element, 'files', { value: [file], configurable: true })
+        await input.trigger('change')
+        expect(wrapper.emitted('upload')[0][0]).toEqual([file])
+        wrapper.unmount()
+    })
+
+    it('accepts an audio file for upload', async () => {
+        const wrapper = await mountDialog()
+        const input = wrapper.find('input[type=file]')
+        const file = new File(['bytes'], 'song.mp3', { type: 'audio/mpeg' })
         Object.defineProperty(input.element, 'files', { value: [file], configurable: true })
         await input.trigger('change')
         expect(wrapper.emitted('upload')[0][0]).toEqual([file])
@@ -296,7 +336,7 @@ describe('ImageChooserDialog', () => {
         await wrapper.find('.chooser-folder').trigger('click')
         await flushBrowse()
         expect(showError).toHaveBeenCalled()
-        expect(wrapper.findAll('.chooser-image')).toHaveLength(3)
+        expect(wrapper.findAll('.chooser-image')).toHaveLength(4)
         wrapper.unmount()
     })
 

--- a/src/components/__tests__/audio_player.test.js
+++ b/src/components/__tests__/audio_player.test.js
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import AudioPlayer from '../audio_player.vue'
+
+// Track every Audio the component creates so tests can assert on play/pause
+// across player generations.
+const instances = []
+class FakeAudio {
+    constructor(url) {
+        this.url = url
+        this.play = vi.fn()
+        this.pause = vi.fn()
+        instances.push(this)
+    }
+}
+vi.stubGlobal('Audio', FakeAudio)
+
+async function setUrl(wrapper, url) {
+    await wrapper.setProps({ audioUrl: url })
+}
+
+describe('audio_player', () => {
+    beforeEach(() => {
+        instances.length = 0
+    })
+
+    it('plays the track when a URL arrives', async () => {
+        const wrapper = mount(AudioPlayer, { props: { audioUrl: '', stop: false } })
+        await setUrl(wrapper, 'track-a')
+        expect(instances).toHaveLength(1)
+        expect(instances[0].url).toBe('track-a')
+        expect(instances[0].play).toHaveBeenCalled()
+    })
+
+    it('keeps playing when the URL empties (background-music semantics)', async () => {
+        const wrapper = mount(AudioPlayer, { props: { audioUrl: '', stop: false } })
+        await setUrl(wrapper, 'track-a')
+        await setUrl(wrapper, '')
+        expect(instances).toHaveLength(1)
+        expect(instances[0].pause).not.toHaveBeenCalled()
+    })
+
+    it('stops the previous track before starting a new one', async () => {
+        const wrapper = mount(AudioPlayer, { props: { audioUrl: '', stop: false } })
+        await setUrl(wrapper, 'track-a')
+        await setUrl(wrapper, 'track-b')
+        expect(instances[0].pause).toHaveBeenCalled()
+        expect(instances[1].url).toBe('track-b')
+        expect(instances[1].play).toHaveBeenCalled()
+    })
+
+    it('stops the previous player when the same page is revisited', async () => {
+        const wrapper = mount(AudioPlayer, { props: { audioUrl: '', stop: false } })
+        await setUrl(wrapper, 'track-a')
+        await setUrl(wrapper, '') // page without audio in between
+        await setUrl(wrapper, 'track-a')
+        expect(instances).toHaveLength(2)
+        expect(instances[0].pause).toHaveBeenCalled()
+        expect(instances[1].play).toHaveBeenCalled()
+    })
+
+    it('pauses on the stop command', async () => {
+        const wrapper = mount(AudioPlayer, { props: { audioUrl: '', stop: false } })
+        await setUrl(wrapper, 'track-a')
+        await wrapper.setProps({ stop: true })
+        expect(instances[0].pause).toHaveBeenCalled()
+    })
+})

--- a/src/components/album.vue
+++ b/src/components/album.vue
@@ -33,7 +33,7 @@
             v-on:add-image="onAddImage"
             v-on:add-text="onAddText" v-on:paint="onPaint" v-on:cycle-layout="onCycleLayout"
             v-on:add-page="onAddPage" v-on:move-page="onMovePage"
-            v-on:element-drop="onElementDrop">
+            v-on:element-drop="onElementDrop" v-on:remove-audio="onRemoveAudio">
 	    </page>
 	    <i v-bind:class="isWinPortrait ? 'arrow-bottom': 'arrow-right'" v-on:click="showNext" v-if="!isTouchDevice"
             v-bind:style="{ visibility: aRightVisible ? 'visible' : 'hidden', }"></i>
@@ -48,7 +48,7 @@
         <videofull v-if="videoFullOn" v-bind:videoUrl="videoFullUrl"
             v-on:click="closeVideoFull" v-on:closevideofull="closeVideoFull">
         </videofull>
-        <AudioPlayer v-bind:audioUrl="audioUrl" v-bind:stop="isStopCmd"></AudioPlayer>
+        <AudioPlayer v-bind:audioUrl="audioUrl" v-bind:stop="isStopCmd || audioForceStop"></AudioPlayer>
         <div v-if="loading" class="center-page">
             <NcLoadingIcon :size="64">
             </NcLoadingIcon>
@@ -76,6 +76,10 @@
         <image-chooser-dialog v-if="imageChooserPageId != null" :saving="imageChooserSaving"
             v-on:close="closeImageChooser" v-on:pick="onImagePick" v-on:upload="onImageUpload">
         </image-chooser-dialog>
+        <NcDialog v-if="audioRemovePageId != null" :name="sRemoveAudioTitle"
+            :message="sRemoveAudioMsg" :buttons="removeAudioButtons"
+            @update:open="onRemoveAudioDialogOpen">
+        </NcDialog>
         <NcModal v-if="downloadModal" @close="closeDownload" size="small">
             <p class="center">{{ sDownloadZip }}</p>
             <div v-if="!downloadActive" class="downloadIcon center" v-on:click="download"></div>
@@ -90,14 +94,14 @@ import Page from './page.vue'
 import Imagefull from './imagefull.vue'
 import Videofull from './videofull.vue'
 import AudioPlayer from './audio_player.vue'
-import { NcLoadingIcon, NcActionInput, NcActionButton, NcActions, NcProgressBar, NcModal, NcActionSeparator, NcButton } from '@nextcloud/vue'
+import { NcLoadingIcon, NcActionInput, NcActionButton, NcActions, NcProgressBar, NcModal, NcActionSeparator, NcButton, NcDialog } from '@nextcloud/vue'
 import Plus from 'vue-material-design-icons/Plus.vue'
 import JSZip from 'jszip'
 import { saveAs } from 'file-saver'
-import { setElementText, setElementGeometry, setElementPanZoom, removeElement, buildImageElement, buildVideoElement, buildTextElement, buildPage, addElement, swapElements, getPaintElement, setPagePaintElement, removePaintElements } from '../utils/albumEdit.js'
+import { setElementText, setElementGeometry, setElementPanZoom, removeElement, buildImageElement, buildVideoElement, buildAudioElement, buildTextElement, buildPage, addElement, swapElements, getPaintElement, setPagePaintElement, removePaintElements, getAudioElement, setPageAudioElement, removeAudioElements, hasVisibleElements } from '../utils/albumEdit.js'
 import { isElementDrag } from '../utils/elementDrag.js'
 import { captureVideoPoster } from '../utils/videoPoster.js'
-import { getFileBlob, VIDEO_MIMES } from '../api/davApi.js'
+import { getFileBlob, VIDEO_MIMES, AUDIO_MIMES } from '../api/davApi.js'
 import { cycleLayout } from '../utils/tilePageLayout.js'
 import { updatePage, searchAsset, cleanAssets, createPage, deletePage, movePage, probeAsset, uploadAsset } from '../api/albumApi.js'
 import PaintDialog from './PaintDialog.vue'
@@ -158,6 +162,14 @@ export default {
             // Same pair for the image chooser dialog.
             "imageChooserPageId": null,
             "imageChooserSaving": false,
+            // Id of the page whose audio-removal confirmation dialog is open
+            // (null = closed), and a forced stop of the audio player after a
+            // removal (the player deliberately keeps playing when the track
+            // URL goes away — background-music semantics).
+            "audioRemovePageId": null,
+            "audioForceStop": false,
+            "sRemoveAudioTitle": t("souvenirs","Remove audio"),
+            "sRemoveAudioMsg": t("souvenirs","Remove this page's audio? The music will no longer play when the page is displayed."),
             // Timestamp of the last page turn triggered by dragging an element
             // near the album edge (throttles the edge navigation).
             "dragNavLast": 0,
@@ -196,6 +208,11 @@ export default {
             } else {
                 clearTimeout(this.diap_timeout);
             }
+        },
+        audioUrl(newValue, oldValue) {
+            // Any track change (new page, re-added audio) cancels the forced
+            // stop from a removal, so the next track plays normally.
+            this.audioForceStop = false;
         }
     },
     computed: {
@@ -242,6 +259,15 @@ export default {
                 }
             }
             return false;
+        },
+        "removeAudioButtons": function() {
+            // NcDialog buttons: a callback that does not return false closes
+            // the dialog after running.
+            var that = this;
+            return [
+                { label: t("souvenirs","Cancel") },
+                { label: t("souvenirs","Remove"), variant: "error", callback: function() { that.confirmRemoveAudio(); } },
+            ];
         },
     },
     methods: {
@@ -442,10 +468,11 @@ export default {
             }
             var that = this;
             var updatedPage = removeElement(this.pages[index], elementId);
-            // Removing the last element of a page deletes the page itself - unless
-            // it is the only page left, which we keep (empty) so the album is not
+            // Removing the last visible element of a page deletes the page itself
+            // (an invisible audio track alone must not keep a blank page alive) -
+            // unless it is the only page left, which we keep so the album is not
             // left with no pages and no way to add one.
-            if (updatedPage.elements.length === 0 && this.pages.length > 1) {
+            if (!hasVisibleElements(updatedPage) && this.pages.length > 1) {
                 this.blockWhile(deletePage(this.albumId, pageId)
                     .then(() => {
                         that.pages.splice(index, 1);
@@ -567,9 +594,10 @@ export default {
             // the element at worst exists on both pages instead of being lost.
             this.blockWhile(updatePage(this.albumId, updatedDest)
                 .then(() => {
-                    // Moving the last element away deletes the emptied page (same
-                    // rule as onRemoveElement), unless it is the only page left.
-                    if (updatedSrc.elements.length === 0 && that.pages.length > 1) {
+                    // Moving the last visible element away deletes the emptied
+                    // page (same rule as onRemoveElement), unless it is the
+                    // only page left.
+                    if (!hasVisibleElements(updatedSrc) && that.pages.length > 1) {
                         return deletePage(that.albumId, srcPageId).then(() => {
                             var i = that.pages.findIndex(p => p.id === srcPageId);
                             if (i >= 0) {
@@ -578,6 +606,9 @@ export default {
                             if (that.displayedPage >= that.pages.length) {
                                 that.displayedPage = that.pages.length - 1;
                             }
+                            // Best-effort GC of the deleted page's assets
+                            // (e.g. its audio track).
+                            return cleanAssets(that.albumId).catch(() => {});
                         });
                     }
                     var i = that.pages.findIndex(p => p.id === srcPageId);
@@ -719,6 +750,42 @@ export default {
             this.imageChooserSaving = false;
             this.imageChooserPageId = pageId;
         },
+        onRemoveAudio: function(pageId) {
+            // Open the confirmation dialog; the actual removal happens in
+            // confirmRemoveAudio (the dialog's Remove button).
+            this.audioRemovePageId = pageId;
+        },
+        onRemoveAudioDialogOpen: function(open) {
+            // Fired when the dialog closes (X, Esc, outside click, or after a
+            // button callback ran).
+            if (!open) {
+                this.audioRemovePageId = null;
+            }
+        },
+        confirmRemoveAudio: function() {
+            var pageId = this.audioRemovePageId;
+            this.audioRemovePageId = null;
+            var index = this.pages.findIndex(p => p.id === pageId);
+            if (index < 0) {
+                return;
+            }
+            var that = this;
+            // No re-layout: audio takes no layout slot, so the visible
+            // elements' geometry must survive the removal.
+            var updatedPage = removeAudioElements(this.pages[index]);
+            this.pages.splice(index, 1, updatedPage);
+            this.blockWhile(updatePage(this.albumId, updatedPage)
+                .then(() => {
+                    // The player deliberately keeps playing when its URL goes
+                    // away; a removed track must actually stop.
+                    that.audioForceStop = true;
+                    // Best-effort GC of the now-unreferenced audio asset.
+                    return cleanAssets(that.albumId).catch(() => {});
+                })
+                .catch(error => {
+                    showError(t("souvenirs","Could not remove the audio."));
+                }));
+        },
         closeImageChooser: function() {
             // Ignore the dialog's close while a chosen image is being saved.
             if (!this.imageChooserSaving) {
@@ -744,15 +811,20 @@ export default {
                 return null;
             }
             const isVideo = VIDEO_MIMES.includes(entry.mime);
+            const isAudio = AUDIO_MIMES.includes(entry.mime);
             // Build the element first so we know the in-album asset path to link,
             // then ask the backend to link the picked file to it.
-            var element = isVideo ? buildVideoElement(file) : buildImageElement(file);
+            var element = isVideo ? buildVideoElement(file)
+                : isAudio ? buildAudioElement(file)
+                : buildImageElement(file);
             try {
-                var res = await searchAsset(this.albumId, isVideo ? element.video : element.image, file.name, file.size);
+                var res = await searchAsset(this.albumId, isVideo ? element.video : (isAudio ? element.audio : element.image), file.name, file.size);
                 if (res == null || res.status !== "found") {
                     showError(isVideo
                         ? t("souvenirs","Could not link the selected video. It must be located outside the Souvenirs albums folder.")
-                        : t("souvenirs","Could not link the selected image. It must be located outside the Souvenirs albums folder."));
+                        : isAudio
+                            ? t("souvenirs","Could not link the selected audio. It must be located outside the Souvenirs albums folder.")
+                            : t("souvenirs","Could not link the selected image. It must be located outside the Souvenirs albums folder."));
                     return null;
                 }
                 if (isVideo) {
@@ -769,7 +841,7 @@ export default {
                 }
                 return element;
             } catch (error) {
-                showError(isVideo ? t("souvenirs","Could not add the video.") : t("souvenirs","Could not add the image."));
+                showError(this.mediaErrorString(element));
                 // GC the link/poster of the never-persisted element.
                 cleanAssets(this.albumId).catch(() => {});
                 return null;
@@ -783,10 +855,12 @@ export default {
             // up over native WebDAV, and the server must confirm the file
             // landed before any page starts referencing it.
             const isVideo = VIDEO_MIMES.includes(file.type);
-            var element = isVideo
-                ? buildVideoElement({ name: file.name, size: file.size, mime: file.type })
-                : buildImageElement({ name: file.name, size: file.size, mime: file.type });
-            const asset = isVideo ? element.video : element.image;
+            const isAudio = AUDIO_MIMES.includes(file.type);
+            const picked = { name: file.name, size: file.size, mime: file.type };
+            var element = isVideo ? buildVideoElement(picked)
+                : isAudio ? buildAudioElement(picked)
+                : buildImageElement(picked);
+            const asset = isVideo ? element.video : (isAudio ? element.audio : element.image);
             try {
                 var probe = await probeAsset(this.albumId, asset);
                 if (probe == null || !probe.path) {
@@ -804,23 +878,37 @@ export default {
             } catch (error) {
                 // GC any bytes that landed before the failure (the element was
                 // never persisted).
-                showError(isVideo ? t("souvenirs","Could not upload the video.") : t("souvenirs","Could not upload the image."));
+                showError(isVideo
+                    ? t("souvenirs","Could not upload the video.")
+                    : isAudio
+                        ? t("souvenirs","Could not upload the audio.")
+                        : t("souvenirs","Could not upload the image."));
                 cleanAssets(this.albumId).catch(() => {});
                 return null;
             }
         },
+        mediaErrorString: function(element) {
+            return element.class === "VideoElement"
+                ? t("souvenirs","Could not add the video.")
+                : element.class === "AudioElement"
+                    ? t("souvenirs","Could not add the audio.")
+                    : t("souvenirs","Could not add the image.");
+        },
         addMediaItems: async function(items, prepare) {
-            // Insert the chosen media in order (issue #36): the first one joins
-            // the page the chooser was opened from (as a single pick always
-            // did), each further one gets its own new page right after — one
-            // medium per page.
+            // Insert the chosen media in order (issue #36): the first visual
+            // medium joins the page the chooser was opened from (as a single
+            // pick always did), each further one gets its own new page right
+            // after — one medium per page. Audio (issue #33) is not a tile: it
+            // becomes the audio track of the page the batch is currently on,
+            // replacing any existing track (last one wins).
             var that = this;
             var targetIndex = this.pages.findIndex(p => p.id === this.imageChooserPageId);
             if (targetIndex < 0 || this.imageChooserSaving || items.length === 0) {
                 return;
             }
             this.imageChooserSaving = true;
-            var inserted = 0;
+            var visualCount = 0;
+            var audioReplaced = false;
             for (const item of items) {
                 var element = await prepare(item);
                 if (element == null) {
@@ -830,31 +918,45 @@ export default {
                     return;
                 }
                 try {
-                    if (inserted === 0) {
+                    if (element.class === "AudioElement") {
+                        // The page the batch is currently on: the target page
+                        // until a visual medium has created a new one. Read the
+                        // page at application time — earlier iterations may
+                        // have replaced the object in `pages`.
+                        var currentIndex = targetIndex + Math.max(0, visualCount - 1);
+                        var current = this.pages[currentIndex];
+                        audioReplaced = audioReplaced || (getAudioElement(current) != null);
+                        var withAudio = setPageAudioElement(current, element);
+                        await updatePage(this.albumId, withAudio);
+                        this.pages.splice(currentIndex, 1, withAudio);
+                    } else if (visualCount === 0) {
                         var updatedPage = addElement(this.pages[targetIndex], element);
                         await updatePage(this.albumId, updatedPage);
                         this.pages.splice(targetIndex, 1, updatedPage);
+                        visualCount++;
                     } else {
-                        var pos = targetIndex + inserted;
+                        var pos = targetIndex + visualCount;
                         var page = addElement(buildPage(), element);
                         await createPage(this.albumId, pos, page);
                         this.pages.splice(pos, 0, page);
+                        visualCount++;
                     }
                 } catch (error) {
                     this.imageChooserSaving = false;
-                    showError(element.class === "VideoElement"
-                        ? t("souvenirs","Could not add the video.")
-                        : t("souvenirs","Could not add the image."));
+                    showError(this.mediaErrorString(element));
                     cleanAssets(this.albumId).catch(() => {});
                     return;
                 }
-                inserted++;
+            }
+            if (audioReplaced) {
+                // Replaced tracks leave their old audio asset orphaned.
+                cleanAssets(this.albumId).catch(() => {});
             }
             this.imageChooserSaving = false;
             this.imageChooserPageId = null;
-            if (inserted > 1) {
+            if (visualCount > 1) {
                 // Land on the last created page so the whole batch is visible.
-                this.$nextTick(() => { that.showN(targetIndex + inserted - 1); });
+                this.$nextTick(() => { that.showN(targetIndex + visualCount - 1); });
             }
         },
         attachVideoPoster: async function(element, videoBlob) {
@@ -905,6 +1007,7 @@ export default {
         "paint-dialog": PaintDialog,
         "image-chooser-dialog": ImageChooserDialog,
         NcModal,
+        NcDialog,
         NcProgressBar,
         NcActions,
         NcActionButton,
@@ -918,15 +1021,6 @@ export default {
     },
 }
 
-var getAudioElement = function(page) {
-    for (let i = 0; i < page.elements.length; i++) {
-        var element = page.elements[i];
-        if (element.class == "AudioElement") {
-            return element;
-        }
-    }
-    return null;
-}
 function basename(path) {
    return path.split('/').reverse()[0];
 }

--- a/src/components/audio_player.vue
+++ b/src/components/audio_player.vue
@@ -20,6 +20,13 @@ export default {
     watch: {
         audioUrl(val, oldVal) {
             if (val != "") {
+                // Only one track plays at a time: without this, re-entering a
+                // page with audio stacks a new player on the still-playing old
+                // one. An empty val keeps the previous track playing
+                // (background-music semantics), so only a new track stops it.
+                if (this.audioPlayer != null) {
+                    this.audioPlayer.pause();
+                }
                 this.audioPlayer = new Audio(val);
                 this.audioPlayer.play();
             }

--- a/src/components/page.vue
+++ b/src/components/page.vue
@@ -27,6 +27,13 @@
             <button class="page-insert__btn"><Plus :size="20" /></button>
             <div class="page-insert__line"></div>
         </div>
+        <div v-if="editMode && audioElement" class="page-audio-badge">
+            <NcButton type="primary" :aria-label="sRemoveAudio" :title="sRemoveAudio" v-on:click="onRemoveAudio">
+                <template #icon>
+                    <MusicNote :size="20" />
+                </template>
+            </NcButton>
+        </div>
         <div v-if="editMode && sNum > 0" class="page-move page-move--left">
             <NcButton type="primary" :aria-label="sMoveLeft" :title="sMoveLeft" v-on:click="onMoveLeft">
                 <template #icon>
@@ -80,7 +87,9 @@ import Brush from 'vue-material-design-icons/Brush.vue'
 import ViewDashboardVariantOutline from 'vue-material-design-icons/ViewDashboardVariantOutline.vue'
 import ChevronLeft from 'vue-material-design-icons/ChevronLeft.vue'
 import ChevronRight from 'vue-material-design-icons/ChevronRight.vue'
+import MusicNote from 'vue-material-design-icons/MusicNote.vue'
 import { canCycleLayout } from '../utils/tilePageLayout.js'
+import { getAudioElement } from '../utils/albumEdit.js'
 import { isElementDrag, getElementDragData } from '../utils/elementDrag.js'
 
 export default {
@@ -108,6 +117,7 @@ export default {
             "sAddPage": t("souvenirs","Add page"),
             "sMoveLeft": t("souvenirs","Move page left"),
             "sMoveRight": t("souvenirs","Move page right"),
+            "sRemoveAudio": t("souvenirs","Remove audio"),
         }
     },
     computed: {
@@ -120,6 +130,9 @@ export default {
         },
         "canCycle": function() {
           return canCycleLayout(this.elements);
+        },
+        "audioElement": function() {
+          return getAudioElement({ elements: this.elements });
         }
     },
     watch: {
@@ -145,6 +158,7 @@ export default {
         ViewDashboardVariantOutline,
         ChevronLeft,
         ChevronRight,
+        MusicNote,
     },
     methods: {
       openImgFull: function(imageUrl,isPhotosphere) {
@@ -223,6 +237,10 @@ export default {
       },
       onMoveRight: function() {
         this.$emit("move-page", this.sNum, 1);
+      },
+      onRemoveAudio: function() {
+        // Ask the album to confirm and remove this page's audio track.
+        this.$emit("remove-audio", this.sId);
       }
     },
     mounted: function() {
@@ -313,6 +331,16 @@ function isFullyVisible(el) {
 
 .page-move--left { left: 16px; }
 .page-move--right { right: 16px; }
+
+/* Audio badge (NcButton): marks a page carrying an audio track in edit mode;
+   clicking it removes the audio (after confirmation). Top-left corner is free
+   (move buttons sit at the bottom, the album menu at the viewport top-right). */
+.page-audio-badge {
+  position: absolute;
+  top: 16px;
+  left: 16px;
+  z-index: 9;
+}
 
 .page-insert__btn {
   pointer-events: all;

--- a/src/utils/__tests__/albumEdit.test.js
+++ b/src/utils/__tests__/albumEdit.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { setElementText, setElementGeometry, setElementPanZoom, relayoutElements, removeElement, buildImageElement, buildVideoElement, buildTextElement, buildPage, addElement, swapElements, getPaintElement, buildPaintElement, setPagePaintElement, removePaintElements } from '../albumEdit.js'
+import { setElementText, setElementGeometry, setElementPanZoom, relayoutElements, removeElement, buildImageElement, buildVideoElement, buildTextElement, buildPage, addElement, swapElements, getPaintElement, buildPaintElement, setPagePaintElement, removePaintElements, getAudioElement, hasVisibleElements, buildAudioElement, setPageAudioElement, removeAudioElements } from '../albumEdit.js'
 
 describe('setElementText', () => {
     const makePage = () => ({
@@ -496,6 +496,141 @@ describe('removePaintElements', () => {
 
     it('tolerates a page without an elements array', () => {
         expect(removePaintElements({ id: 'p' }).elements).toEqual([])
+    })
+})
+
+describe('getAudioElement', () => {
+    it('returns the first audio element of the page', () => {
+        const audio = { id: 'au', class: 'AudioElement', audio: 'data/a.mp3' }
+        const page = { id: 'p', elements: [{ id: 'el-1', class: 'ImageElement' }, audio] }
+        expect(getAudioElement(page)).toBe(audio)
+    })
+
+    it('matches namespaced class names too', () => {
+        const audio = { id: 'au', class: 'fr.nuage.souvenirs.model.AudioElement' }
+        expect(getAudioElement({ elements: [audio] })).toBe(audio)
+    })
+
+    it('returns null when the page has no audio element', () => {
+        expect(getAudioElement({ elements: [{ id: 'el-1', class: 'ImageElement' }] })).toBeNull()
+        expect(getAudioElement({ id: 'p' })).toBeNull()
+    })
+})
+
+describe('hasVisibleElements', () => {
+    it('is false for an empty page and for an audio-only page', () => {
+        expect(hasVisibleElements({ id: 'p', elements: [] })).toBe(false)
+        expect(hasVisibleElements({ id: 'p' })).toBe(false)
+        expect(hasVisibleElements({ id: 'p', elements: [{ id: 'au', class: 'AudioElement' }] })).toBe(false)
+    })
+
+    it('is true as soon as any non-audio element exists (paint renders too)', () => {
+        expect(hasVisibleElements({ elements: [{ id: 'el-1', class: 'ImageElement' }] })).toBe(true)
+        expect(hasVisibleElements({ elements: [{ id: 'pt', class: 'PaintElement' }] })).toBe(true)
+        expect(hasVisibleElements({
+            elements: [{ id: 'au', class: 'AudioElement' }, { id: 'tx', class: 'TextElement' }],
+        })).toBe(true)
+    })
+})
+
+describe('buildAudioElement', () => {
+    it('builds a full-page AudioElement matching the on-disk schema', () => {
+        const el = buildAudioElement({ name: 'song.mp3', size: 4242, mime: 'audio/mpeg' })
+        expect(el.class).toBe('AudioElement')
+        expect(el.audio).toMatch(/^data\/[0-9a-f-]+\.mp3$/)
+        expect(el.id).toBeTruthy()
+        expect(el).toMatchObject({
+            mime: 'audio/mpeg', name: 'song.mp3', size: 4242, stop: false,
+            top: 0, left: 0, right: 100, bottom: 100,
+        })
+    })
+
+    it('tolerates a file name without an extension', () => {
+        const el = buildAudioElement({ name: 'song', size: 1, mime: 'audio/mpeg' })
+        expect(el.audio).toMatch(/^data\/[0-9a-f-]+$/)
+    })
+
+    it('gives each call a distinct element id and asset path', () => {
+        const a = buildAudioElement({ name: 's.mp3', size: 1, mime: 'audio/mpeg' })
+        const b = buildAudioElement({ name: 's.mp3', size: 1, mime: 'audio/mpeg' })
+        expect(a.id).not.toBe(b.id)
+        expect(a.audio).not.toBe(b.audio)
+    })
+})
+
+describe('setPageAudioElement', () => {
+    // An image with a hand-resized (non-default) geometry: it must never be
+    // re-laid-out by audio operations.
+    const image = () => ({ id: 'el-1', class: 'ImageElement', image: 'data/a.jpg', size: 10, top: 12, left: 8, right: 77, bottom: 63 })
+    const audio = () => ({ id: 'au', class: 'AudioElement', audio: 'data/old.mp3', stop: false })
+    const fresh = () => ({ id: 'au-new', class: 'AudioElement', audio: 'data/new.mp3', stop: false })
+
+    it('appends the audio element when the page has none', () => {
+        const result = setPageAudioElement({ id: 'p', elements: [image()] }, fresh())
+        expect(result.elements.map(e => e.id)).toEqual(['el-1', 'au-new'])
+    })
+
+    it('inserts before a paint element so paint stays last', () => {
+        const paint = { id: 'pt', class: 'PaintElement', image: 'data/p.png' }
+        const result = setPageAudioElement({ id: 'p', elements: [image(), paint] }, fresh())
+        expect(result.elements.map(e => e.id)).toEqual(['el-1', 'au-new', 'pt'])
+    })
+
+    it('replaces an existing audio element in its array slot', () => {
+        const result = setPageAudioElement({ id: 'p', elements: [audio(), image()] }, fresh())
+        expect(result.elements.map(e => e.id)).toEqual(['au-new', 'el-1'])
+    })
+
+    it('drops exceeding audio elements, a page holds one track', () => {
+        const extra = { id: 'au2', class: 'AudioElement', audio: 'data/extra.mp3' }
+        const result = setPageAudioElement({ id: 'p', elements: [audio(), image(), extra] }, fresh())
+        expect(result.elements.map(e => e.id)).toEqual(['au-new', 'el-1'])
+    })
+
+    it('never re-lays-out the other elements', () => {
+        const replaced = setPageAudioElement({ id: 'p', elements: [image(), audio()] }, fresh())
+        expect(replaced.elements[0]).toMatchObject({ top: 12, left: 8, right: 77, bottom: 63 })
+        const appended = setPageAudioElement({ id: 'p', elements: [image()] }, fresh())
+        expect(appended.elements[0]).toMatchObject({ top: 12, left: 8, right: 77, bottom: 63 })
+    })
+
+    it('preserves unknown page-level fields and does not mutate the input', () => {
+        const page = { id: 'p', customPageField: 'keep-me', elements: [audio()] }
+        const result = setPageAudioElement(page, fresh())
+        expect(result.customPageField).toBe('keep-me')
+        expect(page.elements[0].id).toBe('au')
+    })
+
+    it('tolerates a page without an elements array', () => {
+        const result = setPageAudioElement({ id: 'p' }, fresh())
+        expect(result.elements.map(e => e.id)).toEqual(['au-new'])
+    })
+})
+
+describe('removeAudioElements', () => {
+    it('removes every audio element and nothing else', () => {
+        const page = {
+            id: 'p',
+            elements: [
+                { id: 'el-1', class: 'ImageElement', image: 'data/a.jpg', top: 12, left: 8, right: 77, bottom: 63 },
+                { id: 'au', class: 'AudioElement', audio: 'data/a.mp3' },
+                { id: 'au2', class: 'fr.nuage.souvenirs.model.AudioElement', audio: 'data/b.mp3' },
+            ],
+        }
+        const result = removeAudioElements(page)
+        expect(result.elements.map(e => e.id)).toEqual(['el-1'])
+        // no re-layout: the survivor keeps its hand-set geometry
+        expect(result.elements[0]).toMatchObject({ top: 12, left: 8, right: 77, bottom: 63 })
+    })
+
+    it('does not mutate the original page', () => {
+        const page = { id: 'p', elements: [{ id: 'au', class: 'AudioElement' }] }
+        removeAudioElements(page)
+        expect(page.elements).toHaveLength(1)
+    })
+
+    it('tolerates a page without an elements array', () => {
+        expect(removeAudioElements({ id: 'p' }).elements).toEqual([])
     })
 })
 

--- a/src/utils/albumEdit.js
+++ b/src/utils/albumEdit.js
@@ -130,6 +130,113 @@ export function buildTextElement() {
     }
 }
 
+function isAudioElement(element) {
+    return element != null && typeof element.class === 'string'
+        && element.class.endsWith('AudioElement')
+}
+
+/**
+ * The page's audio element, or null. Like the Android app, a page holds one
+ * audio track (players play the first AudioElement), so the first match wins.
+ *
+ * @param {object} page - a page object, expected to contain an `elements` array
+ * @returns {object|null}
+ */
+export function getAudioElement(page) {
+    const elements = Array.isArray(page.elements) ? page.elements : []
+    return elements.find(isAudioElement) || null
+}
+
+/**
+ * Whether the page shows anything: audio elements render nothing, everything
+ * else (image/video/text/paint/unknown) does. Used by the "removing the last
+ * element deletes the page" rule, so an invisible audio track alone does not
+ * keep a blank (but music-playing) page alive.
+ *
+ * @param {object} page - a page object, expected to contain an `elements` array
+ * @returns {boolean}
+ */
+export function hasVisibleElements(page) {
+    const elements = Array.isArray(page.elements) ? page.elements : []
+    return elements.some(element => !isAudioElement(element))
+}
+
+/**
+ * Build a fresh AudioElement for a picked Nextcloud file, following the
+ * on-disk format produced by the Android app (`audio` + `stop`, full-page
+ * geometry). As for images, `name`/`size` keep the original file's identity so
+ * the asset-reuse endpoints (assetsearch/clean) can match it. Audio takes no
+ * layout slot, so the caller sets it via `setPageAudioElement` (no re-layout),
+ * not `addElement`.
+ *
+ * @param {object} file - the picked file: `{ name, size, mime }`
+ * @returns {object} a new AudioElement object (not yet placed in a page)
+ */
+export function buildAudioElement({ name, size, mime }) {
+    const dot = name.lastIndexOf('.')
+    const extension = dot >= 0 ? name.slice(dot) : ''
+    return {
+        class: 'AudioElement',
+        id: uuidv4(),
+        audio: 'data/' + uuidv4() + extension,
+        mime: mime,
+        name: name,
+        size: size,
+        stop: false,
+        top: 0,
+        left: 0,
+        right: 100,
+        bottom: 100,
+    }
+}
+
+/**
+ * Return a copy of `page` holding exactly one audio element — `element`
+ * (e.g. from `buildAudioElement`). An existing audio element is replaced in
+ * its array slot (exceeding ones are dropped — a page holds 0 or 1); when the
+ * page had none, the new one goes before any paint element (paint stays last
+ * in the array, as in `addElement`). The other elements are left completely
+ * untouched: audio takes no layout slot, so no re-layout happens and manual
+ * geometry survives.
+ *
+ * @param {object} page - a page object, expected to contain an `elements` array
+ * @param {object} element - the AudioElement to set
+ * @returns {object} a new page object with the single audio element in place
+ */
+export function setPageAudioElement(page, element) {
+    const elements = Array.isArray(page.elements) ? page.elements : []
+    const first = elements.find(isAudioElement)
+    if (first == null) {
+        const paintIndex = elements.findIndex(isPaintElement)
+        const insertAt = paintIndex >= 0 ? paintIndex : elements.length
+        const added = [...elements]
+        added.splice(insertAt, 0, element)
+        return { ...page, elements: added }
+    }
+    return {
+        ...page,
+        elements: elements
+            .filter(e => !isAudioElement(e) || e === first)
+            .map(e => (e === first ? element : e)),
+    }
+}
+
+/**
+ * Return a copy of `page` with every audio element removed. Unlike
+ * `removeElement`, the remaining elements are NOT re-laid-out: audio takes no
+ * layout slot, so removing it must not touch anyone's geometry.
+ *
+ * @param {object} page - a page object, expected to contain an `elements` array
+ * @returns {object} a new page object without audio elements
+ */
+export function removeAudioElements(page) {
+    const elements = Array.isArray(page.elements) ? page.elements : []
+    return {
+        ...page,
+        elements: elements.filter(element => !isAudioElement(element)),
+    }
+}
+
 function isPaintElement(element) {
     return element != null && typeof element.class === 'string'
         && element.class.endsWith('PaintElement')


### PR DESCRIPTION
Closes #33.

## What this does

- **Add audio like an image**: the "Add media" chooser now lists and uploads audio files (mp3, m4a/aac, ogg/opus, wav, flac, webm), marked with a music-note badge and icon fallback when no thumbnail exists. A picked track becomes the page's audio, stored in the Android app's `AudioElement` format (`audio` + `stop`, plus `name`/`size`/`mime` so the backend can re-link lost assets). A page holds one track: picking another replaces it (the orphaned asset is GC'd).
- **Mixed multi-selects**: each audio applies to the page the batch is currently on — `photo1, song1, photo2, song2` gives two pages, each with its own soundtrack. An audio-only pick sets the current page's track.
- **Presence indicator**: an edit-mode-only music-note button at the top-left of any page carrying audio.
- **Removal with confirmation**: clicking the badge opens a "Remove audio" dialog (Cancel / Remove). Confirming removes the track without re-laying-out the visible elements, persists the page, GCs the asset, and force-stops playback.

## Related fixes

- Removing or dragging away the last *visible* element now deletes the page even when an invisible audio element remains (previously an audio-only page survived as a blank, music-playing page); the drag-away deletion also gained the missing asset GC.
- The audio player now stops the previous track before starting a new one — revisiting a page with audio (or reaching another audio page) used to stack a second player on top of the still-playing first one. Moving to a page *without* audio still keeps the track playing (background-music semantics).

No PHP changes: the backend already tracks and GCs `audio` assets.

## Testing

- New vitest coverage: the four `albumEdit.js` audio helpers, chooser audio cases, and a new `audio_player` suite (252 tests pass, PHPUnit suite unchanged).
- Verified end-to-end with Playwright against a local Nextcloud snap: mixed image+audio upload, Android-schema `album.json`, asset upload to `data/`, badge only in edit mode, Cancel vs Remove, and asset GC after removal.