### PR TITLE
Reset button toggles cover-fit and whole-image fit (#45)

### DIFF
--- a/src/components/__tests__/selement.panzoom.test.js
+++ b/src/components/__tests__/selement.panzoom.test.js
@@ -182,14 +182,41 @@ describe('selement pan & zoom reset button', () => {
         ])
     })
 
-    it('does not persist anything when the element already renders as cover-fit', async () => {
+    it('fits the whole image when the element already renders as cover-fit', async () => {
         // Zoom-offset at the defaults, and center-crop (the same rendering).
-        const zoomOffset = await mountImageTile()
-        await zoomOffset.find('.s-element-pan-reset').trigger('click')
-        expect(zoomOffset.emitted('pan-zoom-element')).toBeFalsy()
-        const centerCrop = await mountImageTile({ sTransformType: 1, sZoom: 0 })
-        await centerCrop.find('.s-element-pan-reset').trigger('click')
-        expect(centerCrop.emitted('pan-zoom-element')).toBeFalsy()
+        // 2000x1000 image in the 500x500 box: contain-fit is zoom 50, centered
+        // by offsets of 50 * (100/50 - 1) = 50% on both axes.
+        for (const props of [{}, { sTransformType: 1, sZoom: 0 }]) {
+            const wrapper = await mountImageTile(props)
+            wrapper.vm.imgSize = { width: 2000, height: 1000 }
+            await wrapper.vm.$nextTick()
+            await wrapper.find('.s-element-pan-reset').trigger('click')
+            expect(wrapper.emitted('pan-zoom-element')).toEqual([
+                ['el-1', { zoom: 50, offsetX: 50, offsetY: 50, transformType: 2 }],
+            ])
+        }
+    })
+
+    it('does not persist a fit that matches cover-fit (same aspect ratios)', async () => {
+        // The default fixture is a square image in the square box.
+        const wrapper = await mountImageTile()
+        await wrapper.find('.s-element-pan-reset').trigger('click')
+        expect(wrapper.emitted('pan-zoom-element')).toBeFalsy()
+    })
+
+    it('toggles back to cover-fit from the fitted state', async () => {
+        const wrapper = await mountImageTile({ sZoom: 50, sOffsetX: 50, sOffsetY: 50 })
+        await wrapper.find('.s-element-pan-reset').trigger('click')
+        expect(wrapper.emitted('pan-zoom-element')).toEqual([
+            ['el-1', { zoom: 100, offsetX: 0, offsetY: 0, transformType: 2 }],
+        ])
+    })
+
+    it('labels the button with the framing the next press applies', async () => {
+        const atDefault = await mountImageTile()
+        expect(atDefault.find('.s-element-pan-reset').attributes('title')).toBe('Fit whole image')
+        const zoomed = await mountImageTile({ sZoom: 180 })
+        expect(zoomed.find('.s-element-pan-reset').attributes('title')).toBe('Reset zoom and position')
     })
 
     it('discards a pending wheel preview instead of committing it', async () => {

--- a/src/components/selement.vue
+++ b/src/components/selement.vue
@@ -18,10 +18,11 @@
 				<CursorMove :size="20" />
 			</template>
 		</NcButton>
-		<!-- Back to the default framing (cover-fit: zoom 100, no offset) after
-		     pan & zoom gestures. -->
+		<!-- Toggles the framing (issue #45): back to the default cover-fit
+		     (zoom 100, no offset) after pan & zoom gestures, or — when already
+		     at the default — to a centered contain-fit showing the whole image. -->
 		<NcButton v-if="editMode && sClass.endsWith('ImageElement')" class="s-element-pan-reset" type="primary"
-			:aria-label="sResetPanZoom" :title="sResetPanZoom" v-on:click="onPanZoomReset">
+			:aria-label="resetPanZoomTitle" :title="resetPanZoomTitle" v-on:click="onPanZoomReset">
 			<template #icon>
 				<FitToScreen :size="20" />
 			</template>
@@ -91,7 +92,7 @@ import Delete from 'vue-material-design-icons/Delete.vue'
 import CursorMove from 'vue-material-design-icons/CursorMove.vue'
 import FitToScreen from 'vue-material-design-icons/FitToScreen.vue'
 import { setElementDragData, isElementDrag, getElementDragData } from '../utils/elementDrag.js'
-import { initialPanZoom, panBy, zoomAt, roundPanZoom } from '../utils/imagePanZoom.js'
+import { initialPanZoom, panBy, zoomAt, roundPanZoom, containPanZoom } from '../utils/imagePanZoom.js'
 
 // Zoom speed of the mouse wheel: multiplicative factor e^(-deltaY * this).
 // 0.002 gives ~±22% per classic 100-unit wheel notch.
@@ -146,7 +147,6 @@ export default {
             "panZoomPreview": null,
             "sDragToMove": t("souvenirs","Drag to move"),
             "sDragToResize": t("souvenirs","Drag to resize"),
-            "sResetPanZoom": t("souvenirs","Reset zoom and position"),
             "resizeCorners": ['nw', 'ne', 'sw', 'se'],
             // State of the corner drag in progress (pointer id, start position,
             // page size in px, original geometry), null when not resizing.
@@ -274,6 +274,26 @@ export default {
         },
         'effectiveZoom': function() {
             return this.panZoomPreview != null ? this.panZoomPreview.zoom : this.sZoom;
+        },
+        'isCommittedCoverFit': function() {
+            // The committed props render as the default framing: zoom-offset at
+            // the defaults, or center-crop (the same rendering).
+            return (this.sTransformType === IMG_ZOOMOFFSET && this.sZoom === 100
+                    && this.sOffsetX === 0 && this.sOffsetY === 0)
+                || this.sTransformType === IMG_CENTERCROP;
+        },
+        'isEffectiveCoverFit': function() {
+            // What the user currently sees: the pending preview when there is
+            // one, the committed props otherwise.
+            if (this.panZoomPreview != null) {
+                return this.panZoomPreview.zoom === 100 && this.panZoomPreview.offsetX === 0
+                    && this.panZoomPreview.offsetY === 0;
+            }
+            return this.isCommittedCoverFit;
+        },
+        'resetPanZoomTitle': function() {
+            return this.isEffectiveCoverFit ? t("souvenirs","Fit whole image")
+                : t("souvenirs","Reset zoom and position");
         },
         'canPanZoom': function() {
             // Pan & zoom applies to image elements in edit mode (issue #27),
@@ -600,27 +620,48 @@ export default {
                 { zoom: rounded.zoom, offsetX: rounded.offsetX, offsetY: rounded.offsetY, transformType: IMG_ZOOMOFFSET });
         },
         onPanZoomReset: function() {
-            // Back to the default framing: drop any gesture in progress and any
-            // pending wheel commit, then persist plain cover-fit — unless the
-            // committed element already renders that way (zoom-offset at
-            // 100/0/0, or center-crop, which is the same rendering).
+            // Toggle the framing (issue #45), dropping any gesture in progress
+            // and any pending wheel commit first. Away from the default the
+            // button persists plain cover-fit, as before; from the default
+            // framing it fits the whole image in the tile instead (centered
+            // contain, over the blurred backdrop).
             if (this.wheelCommitTimer != null) {
                 clearTimeout(this.wheelCommitTimer);
                 this.wheelCommitTimer = null;
             }
             this.panZoomGesture = null;
-            var isDefault = (this.sTransformType === IMG_ZOOMOFFSET && this.sZoom === 100
-                    && this.sOffsetX === 0 && this.sOffsetY === 0)
-                || this.sTransformType === IMG_CENTERCROP;
-            if (isDefault) {
+            if (!this.isEffectiveCoverFit) {
+                // A non-default preview over default committed props just gets
+                // discarded: the committed rendering is already cover-fit.
+                if (this.isCommittedCoverFit) {
+                    this.panZoomPreview = null;
+                    this.refreshImageStyle();
+                    return;
+                }
+                this.panZoomPreview = { zoom: 100, offsetX: 0, offsetY: 0 };
+                this.refreshImageStyle();
+                this.$emit("pan-zoom-element", this.sId,
+                    { zoom: 100, offsetX: 0, offsetY: 0, transformType: IMG_ZOOMOFFSET });
+                return;
+            }
+            if (this.imgSize == null || this.imgSize.width <= 0 || this.imgSize.height <= 0) {
+                return;
+            }
+            var box = this.$refs.eldiv.getBoundingClientRect();
+            if (box.width <= 0 || box.height <= 0) {
+                return;
+            }
+            var fit = roundPanZoom(containPanZoom(box, this.imgSize));
+            // Aspect ratios match: contain-fit is cover-fit, nothing to change.
+            if (fit.zoom === 100) {
                 this.panZoomPreview = null;
                 this.refreshImageStyle();
                 return;
             }
-            this.panZoomPreview = { zoom: 100, offsetX: 0, offsetY: 0 };
+            this.panZoomPreview = fit;
             this.refreshImageStyle();
             this.$emit("pan-zoom-element", this.sId,
-                { zoom: 100, offsetX: 0, offsetY: 0, transformType: IMG_ZOOMOFFSET });
+                { zoom: fit.zoom, offsetX: fit.offsetX, offsetY: fit.offsetY, transformType: IMG_ZOOMOFFSET });
         },
         onResizeStart: function(event, corner) {
             if (!this.isResizable || this.resizing != null) {

--- a/src/utils/__tests__/imagePanZoom.test.js
+++ b/src/utils/__tests__/imagePanZoom.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { initialPanZoom, panBy, zoomAt, roundPanZoom, ZOOM_MIN, ZOOM_MAX } from '../imagePanZoom.js'
+import { initialPanZoom, panBy, zoomAt, roundPanZoom, containPanZoom, ZOOM_MIN, ZOOM_MAX } from '../imagePanZoom.js'
 
 // A square image in a square box: cover-fit fills the box exactly, which makes
 // the expected values easy to derive by hand.
@@ -22,10 +22,31 @@ describe('initialPanZoom', () => {
             .toEqual({ zoom: 100, offsetX: 0, offsetY: 0 })
     })
 
-    it('maps fill (contain) to the visually equivalent zoom', () => {
+    it('maps fill (contain) to the visually equivalent centered state', () => {
         // 2000x1000 image in a 1000x1000 box: contain scale 0.5, cover scale 1.
         expect(initialPanZoom({ transformType: 0, zoom: 0, offsetX: 0, offsetY: 0 }, BOX, { width: 2000, height: 1000 }))
-            .toEqual({ zoom: 50, offsetX: 0, offsetY: 0 })
+            .toEqual({ zoom: 50, offsetX: 50, offsetY: 50 })
+    })
+})
+
+describe('containPanZoom', () => {
+    it('fits the whole image centered in the box', () => {
+        // 2000x1000 image in a 1000x1000 box: contain scale 0.5, cover scale 1,
+        // and centering needs offsets of 50 * (100/50 - 1) = 50% on both axes
+        // (the layout scales about the box's top-left corner).
+        expect(containPanZoom(BOX, { width: 2000, height: 1000 }))
+            .toEqual({ zoom: 50, offsetX: 50, offsetY: 50 })
+    })
+
+    it('is the identity when the aspect ratios match', () => {
+        expect(containPanZoom(BOX, IMG)).toEqual({ zoom: 100, offsetX: 0, offsetY: 0 })
+    })
+
+    it('clamps the zoom to ZOOM_MIN for extreme aspect ratios', () => {
+        // 20000x1000 image: contain/cover would be zoom 5, below the minimum;
+        // the offsets center the image at the clamped zoom.
+        expect(containPanZoom(BOX, { width: 20000, height: 1000 }))
+            .toEqual({ zoom: ZOOM_MIN, offsetX: 450, offsetY: 450 })
     })
 })
 

--- a/src/utils/imagePanZoom.js
+++ b/src/utils/imagePanZoom.js
@@ -64,11 +64,30 @@ function clampState(state, box, img) {
 }
 
 /**
+ * The zoom-offset state that shows the whole image centered in the box
+ * (contain-fit, like CSS object-fit: contain). The zoom is the contain/cover
+ * scale ratio; since the rendered layout is scaled about the box's top-left
+ * (P(q) above), keeping the image centered needs matching offsets, from
+ * P(0) = (box - cover*z)/2: offset% = 50 * (100/zoom - 1) on both axes.
+ *
+ * @param {{width: number, height: number}} box
+ * @param {{width: number, height: number}} img
+ * @returns {{zoom: number, offsetX: number, offsetY: number}}
+ */
+export function containPanZoom(box, img) {
+    const contain = Math.min(box.width / img.width, box.height / img.height)
+    const cover = Math.max(box.width / img.width, box.height / img.height)
+    const zoom = clamp(100 * contain / cover, ZOOM_MIN, ZOOM_MAX)
+    const offset = 50 * (100 / zoom - 1)
+    return { zoom: zoom, offsetX: offset, offsetY: offset }
+}
+
+/**
  * The pan/zoom state a gesture starts from, for any of the three transform
  * types. Zoom-offset elements keep their stored values; center-crop is exactly
  * zoom-offset at (100, 0, 0); fill (contain) converts to the equivalent
- * zoom-offset zoom (100 * containScale / coverScale), so switching the element
- * to zoom-offset on the first gesture does not visually jump.
+ * centered contain-fit state, so switching the element to zoom-offset on the
+ * first gesture does not visually jump.
  *
  * @param {{transformType: number, zoom: number, offsetX: number, offsetY: number}} element
  * @param {{width: number, height: number}} box
@@ -84,9 +103,7 @@ export function initialPanZoom(element, box, img) {
         }, box, img)
     }
     if (element.transformType === IMG_FILL) {
-        const contain = Math.min(box.width / img.width, box.height / img.height)
-        const cover = Math.max(box.width / img.width, box.height / img.height)
-        return clampState({ zoom: 100 * contain / cover, offsetX: 0, offsetY: 0 }, box, img)
+        return clampState(containPanZoom(box, img), box, img)
     }
     // IMG_CENTERCROP (and anything unknown): plain cover-fit.
     return { zoom: 100, offsetX: 0, offsetY: 0 }


### PR DESCRIPTION
Closes #45.

## What

In edit mode, the image reset button (FitToScreen icon) now toggles the framing:

- element not at the default framing (zoomed, panned, or fill) → reset to cover-fit (zoom 100, offsets 0), unchanged behavior;
- element already at the default cover-fit → fit the **whole image centered** in the tile (contain-fit, letterboxed over the existing blurred backdrop).

The button title/aria-label follows the framing the next press applies ("Fit whole image" / "Reset zoom and position").

## How

- New pure helper `containPanZoom(box, img)` in `src/utils/imagePanZoom.js`. The zoom-offset transform scales about the tile's top-left corner, so a *centered* contain-fit is not just the fit zoom with zero offsets: it needs `zoom = 100·contain/cover` plus `offsetX = offsetY = 50·(100/zoom − 1)` %.
- `onPanZoomReset` in `selement.vue` decides on the effective state (pending preview if any, else committed props), so resetting during a pending wheel zoom still just discards the preview as before.
- Also reused the helper for the fill → zoom-offset conversion at gesture start (`initialPanZoom`), which claimed to be visually equivalent to `object-fit: contain` but was left/top-shifted with its zero offsets.

## Testing

- Unit tests updated/added for `containPanZoom` and the reset toggle (fit press, no-op on matching aspect ratios, round-trip back to cover-fit, dynamic label); full vitest suite passes (264 tests).
- Verified end-to-end in the browser against a local Nextcloud: a 2:1 image in a tall tile persisted exactly `{zoom: 50, offsetX: 50, offsetY: 50, transformType: 2}` on the first press (whole image centered over the blurred backdrop), returned to `{100, 0, 0}` on the second, and reset to cover-fit after a pan.